### PR TITLE
RSDK-2183 - Query for valid SDP names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/sdk",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/sdk",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.34"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/sdk",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "",
   "main": "./dist/main.umd.js",
   "module": "./dist/main.es.js",

--- a/src/extra/stream/Client.ts
+++ b/src/extra/stream/Client.ts
@@ -36,25 +36,30 @@ export class StreamClient extends EventDispatcher implements Stream {
   async add(name: string) {
     const streamService = this.streamService;
     const request = new pb.AddStreamRequest();
-    request.setName(this.getValidSDPTrackName(name));
-    console.log(this.getValidSDPTrackName(name))
+    const valName = this.getValidSDPTrackName(name)
+    request.setName(valName);
     this.options.requestLogger?.(request);
     try {
       await promisify<pb.AddStreamRequest, pb.AddStreamResponse>(
         streamService.addStream.bind(streamService),
         request
       );
-    } catch (e) {
-      console.log(e)
+    } catch (error) {
+      // try again with just the resource name
+      request.setName(name);
+      this.options.requestLogger?.(request);
+      await promisify<pb.AddStreamRequest, pb.AddStreamResponse>(
+        streamService.addStream.bind(streamService),
+        request
+      );
     }
-
   }
 
   async remove(name: string) {
     const streamService = this.streamService;
     const request = new pb.RemoveStreamRequest();
-    request.setName(this.getValidSDPTrackName(name));
-    console.log(this.getValidSDPTrackName(name))
+    const valName = this.getValidSDPTrackName(name)
+    request.setName(valName);
     this.options.requestLogger?.(request);
     try {
       await promisify<pb.RemoveStreamRequest, pb.RemoveStreamResponse>(
@@ -62,7 +67,13 @@ export class StreamClient extends EventDispatcher implements Stream {
         request
       );
     } catch (e) {
-      console.log(e)
+      // try again with just the resource name
+      request.setName(name);
+      this.options.requestLogger?.(request);
+      await promisify<pb.RemoveStreamRequest, pb.RemoveStreamResponse>(
+        streamService.removeStream.bind(streamService),
+        request
+      );
     }
   }
 }

--- a/src/extra/stream/Client.ts
+++ b/src/extra/stream/Client.ts
@@ -27,29 +27,42 @@ export class StreamClient extends EventDispatcher implements Stream {
     return this.client;
   }
 
+  // Returns a valid SDP video/audio track name as defined in RFC 4566 (https://www.rfc-editor.org/rfc/rfc4566)
+  // where track names should not include colons.
+  private getValidSDPTrackName(name: string) {
+    return name.replaceAll(":", "+")
+  }
+
   async add(name: string) {
     const streamService = this.streamService;
     const request = new pb.AddStreamRequest();
-    request.setName(name);
-
+    request.setName(this.getValidSDPTrackName(name));
+    console.log(this.getValidSDPTrackName(name))
     this.options.requestLogger?.(request);
+    try {
+      await promisify<pb.AddStreamRequest, pb.AddStreamResponse>(
+        streamService.addStream.bind(streamService),
+        request
+      );
+    } catch (e) {
+      console.log(e)
+    }
 
-    await promisify<pb.AddStreamRequest, pb.AddStreamResponse>(
-      streamService.addStream.bind(streamService),
-      request
-    );
   }
 
   async remove(name: string) {
     const streamService = this.streamService;
     const request = new pb.RemoveStreamRequest();
-    request.setName(name);
-
+    request.setName(this.getValidSDPTrackName(name));
+    console.log(this.getValidSDPTrackName(name))
     this.options.requestLogger?.(request);
-
-    await promisify<pb.RemoveStreamRequest, pb.RemoveStreamResponse>(
-      streamService.removeStream.bind(streamService),
-      request
-    );
+    try {
+      await promisify<pb.RemoveStreamRequest, pb.RemoveStreamResponse>(
+        streamService.removeStream.bind(streamService),
+        request
+      );
+    } catch (e) {
+      console.log(e)
+    }
   }
 }


### PR DESCRIPTION
tested in conjunction with https://github.com/viamrobotics/rdk/pull/2115
also works with RDKs on main.
Deploy order is approximately TS SDK -> RC -> APP -> actual change in RDK