### PR TITLE
Cleanup test mocks

### DIFF
--- a/src/robot/session-manager.test.ts
+++ b/src/robot/session-manager.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment happy-dom
 
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ConnectionClosedError } from '@viamrobotics/rpc';
 import { FakeTransportBuilder } from '@improbable-eng/grpc-web-fake-transport';
 import { grpc } from '@improbable-eng/grpc-web';
 import { RobotServiceClient } from '../gen/robot/v1/robot_pb_service';
+vi.mock('../gen/robot/v1/robot_pb_service');
 
 import SessionManager from './session-manager';
 
@@ -26,11 +27,6 @@ const mockHealthyHeartbeat = (_req, _md, cb) => {
 describe('SessionManager', () => {
   beforeEach(() => {
     sm = new SessionManager(host, transport);
-    vi.doMock('./gen/robot/v1/robot_pb_service');
-  });
-
-  afterEach(() => {
-    vi.clearAllMocks();
   });
 
   test('no session initially', () => {

--- a/src/robot/session-manager.test.ts
+++ b/src/robot/session-manager.test.ts
@@ -26,7 +26,7 @@ const mockHealthyHeartbeat = (_req, _md, cb) => {
 describe('SessionManager', () => {
   beforeEach(() => {
     sm = new SessionManager(host, transport);
-    vi.mock('./gen/robot/v1/robot_pb_service');
+    vi.doMock('./gen/robot/v1/robot_pb_service');
   });
 
   afterEach(() => {


### PR DESCRIPTION
Update: now uses conventions established in other tests - see https://github.com/viamrobotics/viam-typescript-sdk/pull/141 for related discussion.

---

Clean up mocks for existing test

Context: https://github.com/viamrobotics/viam-typescript-sdk/pull/41/files#r1156191232