### PR TITLE
Add docs build to makefile

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,6 @@ jobs:
           sudo chown -R testbot .
           sudo -u testbot bash -lc 'make build'
 
-      - name: Generate docs
-        run: npm run doc
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,14 @@ You'll need to make sure the following tools are installed on your machine and a
 
 ### Makefile targets
 
-To get started, run `make all` to install development dependencies, run checks, and build the distributable artifacts:
+To get started, run `make all` to install development dependencies, run checks, build the distributable artifacts, and build docs:
 
 ```shell
+# run sequentially
 make all
+
+# run in parallel
+make all -j
 ```
 
 You can also use individual targets:

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ teardown:
 	rm -rf node_modules
 
 .PHONY: build
-build: build-buf build-js
+build: build-buf build-js build-docs
 
 .PHONY: clean
-clean: clean-js clean-buf
+clean: clean-js clean-buf clean-docs
 
 .PHONY: test
 test: $(node_modules) build-buf
@@ -70,3 +70,13 @@ build-js: $(node_modules) clean-js build-buf
 .PHONY: pack
 pack: build
 	npm pack
+
+# docs targes
+
+.PHONY: clean-docs
+clean-docs:
+	rm -rf docs/dist
+
+.PHONY: build-docs
+build-docs: build-buf
+	npm run doc

--- a/Makefile
+++ b/Makefile
@@ -78,5 +78,5 @@ clean-docs:
 	rm -rf docs/dist
 
 .PHONY: build-docs
-build-docs: build-buf
+build-docs: clean-docs build-buf
 	npm run doc


### PR DESCRIPTION
## Overview

This PR adds building the docs to the Makefile's `build` and `clean` targets (and therefore, also its `all` target). It depends on the `build-buf` target to ensure generated types are present.

This means that pull request CI will now fail if the docs build is broken, which I've been paranoid about!

## Test plan

- Ensure CI stays green
- Try it out locally

```shell
# should clean and build everything, including docs
make all

# should clean and build everything, but in half the time using parallel jobs
make all -j

# if you're using GNU make, this runs in parallel put prints output in sequence
make all -j -O
```