### PR TITLE
Fix most lints

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,7 +43,6 @@ module.exports = {
     '@typescript-eslint/no-misused-promises': 'warn',
     '@typescript-eslint/no-unsafe-argument': 'warn',
     '@typescript-eslint/no-unsafe-call': 'warn',
-    'import/order': 'warn',
     'sonarjs/no-collapsible-if': 'warn',
     'sonarjs/prefer-immediate-return': 'warn',
     'unicorn/no-array-for-each': 'warn',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,8 +43,6 @@ module.exports = {
     '@typescript-eslint/no-misused-promises': 'warn',
     '@typescript-eslint/no-unsafe-argument': 'warn',
     '@typescript-eslint/no-unsafe-call': 'warn',
-    'sonarjs/no-collapsible-if': 'warn',
-    'sonarjs/prefer-immediate-return': 'warn',
     'unicorn/no-array-for-each': 'warn',
     'unicorn/catch-error-name': 'warn',
     'unicorn/filename-case': 'warn',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,8 +18,6 @@ module.exports = {
   },
   rules: {
     // TODO(mc, 2023-04-06): remove overrides to default to error, fix issues
-    curly: 'warn',
-    'func-names': 'warn',
     'id-length': [
       'warn',
       {
@@ -40,15 +38,9 @@ module.exports = {
         ],
       },
     ],
-    'lines-between-class-members': [
-      'warn',
-      'always',
-      { exceptAfterSingleLine: true },
-    ],
     'prefer-destructuring': 'warn',
     '@typescript-eslint/no-floating-promises': 'warn',
     '@typescript-eslint/no-misused-promises': 'warn',
-    '@typescript-eslint/no-unnecessary-type-assertion': 'warn',
     '@typescript-eslint/no-unsafe-argument': 'warn',
     '@typescript-eslint/no-unsafe-call': 'warn',
     'import/order': 'warn',
@@ -59,9 +51,7 @@ module.exports = {
     'unicorn/filename-case': 'warn',
     'unicorn/no-instanceof-array': 'warn',
     'unicorn/no-lonely-if': 'warn',
-    'unicorn/no-useless-undefined': 'warn',
     'unicorn/prefer-add-event-listener': 'warn',
     'unicorn/prefer-export-from': 'warn',
-    'unicorn/prefer-optional-catch-binding': 'warn',
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,37 +18,13 @@ module.exports = {
   },
   rules: {
     // TODO(mc, 2023-04-06): remove overrides to default to error, fix issues
-    'id-length': [
-      'warn',
-      {
-        exceptions: [
-          '_',
-          'x',
-          'y',
-          'z',
-          'w',
-          'r',
-          'i',
-          'j',
-          'k',
-          'l',
-          'h',
-          'a',
-          'b',
-        ],
-      },
-    ],
-    'prefer-destructuring': 'warn',
+
+    // 'prefer-destructuring': 'warn',
     '@typescript-eslint/no-floating-promises': 'warn',
     '@typescript-eslint/no-misused-promises': 'warn',
     '@typescript-eslint/no-unsafe-argument': 'warn',
     '@typescript-eslint/no-unsafe-call': 'warn',
-    'unicorn/no-array-for-each': 'warn',
-    'unicorn/catch-error-name': 'warn',
     'unicorn/filename-case': 'warn',
-    'unicorn/no-instanceof-array': 'warn',
-    'unicorn/no-lonely-if': 'warn',
     'unicorn/prefer-add-event-listener': 'warn',
-    'unicorn/prefer-export-from': 'warn',
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,8 +18,6 @@ module.exports = {
   },
   rules: {
     // TODO(mc, 2023-04-06): remove overrides to default to error, fix issues
-
-    // 'prefer-destructuring': 'warn',
     '@typescript-eslint/no-floating-promises': 'warn',
     '@typescript-eslint/no-misused-promises': 'warn',
     '@typescript-eslint/no-unsafe-argument': 'warn',

--- a/src/components/base/Client.ts
+++ b/src/components/base/Client.ts
@@ -28,7 +28,7 @@ export class BaseClient implements Base {
   }
 
   async moveStraight(distanceMm: number, mmPerSec: number, extra = {}) {
-    const {baseService} = this;
+    const { baseService } = this;
     const request = new pb.MoveStraightRequest();
     request.setName(this.name);
     request.setMmPerSec(mmPerSec);
@@ -44,7 +44,7 @@ export class BaseClient implements Base {
   }
 
   async spin(angleDeg: number, degsPerSec: number, extra = {}) {
-    const {baseService} = this;
+    const { baseService } = this;
     const request = new pb.SpinRequest();
     request.setName(this.name);
     request.setAngleDeg(angleDeg);
@@ -60,7 +60,7 @@ export class BaseClient implements Base {
   }
 
   async setPower(linear: Vector3D, angular: Vector3D, extra = {}) {
-    const {baseService} = this;
+    const { baseService } = this;
     const request = new pb.SetPowerRequest();
     request.setName(this.name);
     request.setLinear(encodeVector3D(linear));
@@ -76,7 +76,7 @@ export class BaseClient implements Base {
   }
 
   async setVelocity(linear: Vector3D, angular: Vector3D, extra = {}) {
-    const {baseService} = this;
+    const { baseService } = this;
     const request = new pb.SetVelocityRequest();
     request.setName(this.name);
     request.setLinear(encodeVector3D(linear));
@@ -92,7 +92,7 @@ export class BaseClient implements Base {
   }
 
   async stop(extra = {}) {
-    const {baseService} = this;
+    const { baseService } = this;
     const request = new pb.StopRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/base/Client.ts
+++ b/src/components/base/Client.ts
@@ -2,10 +2,10 @@ import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 
 import type { RobotClient } from '../../robot';
 import pb from '../../gen/component/base/v1/base_pb';
-import type { Base } from './Base';
 import { BaseServiceClient } from '../../gen/component/base/v1/base_pb_service';
 import type { Options, Vector3D } from '../../types';
 import { promisify, encodeVector3D } from '../../utils';
+import type { Base } from './Base';
 
 /**
  * A gRPC-web client for the Base component.

--- a/src/components/base/Client.ts
+++ b/src/components/base/Client.ts
@@ -28,7 +28,7 @@ export class BaseClient implements Base {
   }
 
   async moveStraight(distanceMm: number, mmPerSec: number, extra = {}) {
-    const baseService = this.baseService;
+    const {baseService} = this;
     const request = new pb.MoveStraightRequest();
     request.setName(this.name);
     request.setMmPerSec(mmPerSec);
@@ -44,7 +44,7 @@ export class BaseClient implements Base {
   }
 
   async spin(angleDeg: number, degsPerSec: number, extra = {}) {
-    const baseService = this.baseService;
+    const {baseService} = this;
     const request = new pb.SpinRequest();
     request.setName(this.name);
     request.setAngleDeg(angleDeg);
@@ -60,7 +60,7 @@ export class BaseClient implements Base {
   }
 
   async setPower(linear: Vector3D, angular: Vector3D, extra = {}) {
-    const baseService = this.baseService;
+    const {baseService} = this;
     const request = new pb.SetPowerRequest();
     request.setName(this.name);
     request.setLinear(encodeVector3D(linear));
@@ -76,7 +76,7 @@ export class BaseClient implements Base {
   }
 
   async setVelocity(linear: Vector3D, angular: Vector3D, extra = {}) {
-    const baseService = this.baseService;
+    const {baseService} = this;
     const request = new pb.SetVelocityRequest();
     request.setName(this.name);
     request.setLinear(encodeVector3D(linear));
@@ -92,7 +92,7 @@ export class BaseClient implements Base {
   }
 
   async stop(extra = {}) {
-    const baseService = this.baseService;
+    const {baseService} = this;
     const request = new pb.StopRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/board/Client.ts
+++ b/src/components/board/Client.ts
@@ -29,7 +29,7 @@ export class BoardClient implements Board {
   }
 
   private async getRawStatusResponse(extra = {}): Promise<pb.StatusResponse> {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.StatusRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -75,7 +75,7 @@ export class BoardClient implements Board {
   }
 
   async setGPIO(pin: string, high: boolean, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.SetGPIORequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -91,7 +91,7 @@ export class BoardClient implements Board {
   }
 
   async getGPIO(pin: string, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.GetGPIORequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -107,7 +107,7 @@ export class BoardClient implements Board {
   }
 
   async getPWM(pin: string, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.PWMRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -123,7 +123,7 @@ export class BoardClient implements Board {
   }
 
   async setPWM(pin: string, dutyCyle: number, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.SetPWMRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -139,7 +139,7 @@ export class BoardClient implements Board {
   }
 
   async getPWMFrequency(pin: string, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.PWMFrequencyRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -155,7 +155,7 @@ export class BoardClient implements Board {
   }
 
   async setPWMFrequency(pin: string, frequencyHz: number, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.SetPWMFrequencyRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -171,7 +171,7 @@ export class BoardClient implements Board {
   }
 
   async readAnalogReader(analogReader: string, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.ReadAnalogReaderRequest();
     request.setBoardName(this.name);
     request.setAnalogReaderName(analogReader);
@@ -187,7 +187,7 @@ export class BoardClient implements Board {
   }
 
   async getDigitalInterruptValue(digitalInteruptName: string, extra = {}) {
-    const boardService = this.boardService;
+    const {boardService} = this;
     const request = new pb.GetDigitalInterruptValueRequest();
     request.setBoardName(this.name);
     request.setDigitalInterruptName(digitalInteruptName);

--- a/src/components/board/Client.ts
+++ b/src/components/board/Client.ts
@@ -90,6 +90,7 @@ export class BoardClient implements Board {
       request
     );
   }
+
   async getGPIO(pin: string, extra = {}) {
     const boardService = this.boardService;
     const request = new pb.GetGPIORequest();
@@ -105,6 +106,7 @@ export class BoardClient implements Board {
     );
     return response.getHigh();
   }
+
   async getPWM(pin: string, extra = {}) {
     const boardService = this.boardService;
     const request = new pb.PWMRequest();
@@ -120,6 +122,7 @@ export class BoardClient implements Board {
     );
     return response.getDutyCyclePct();
   }
+
   async setPWM(pin: string, dutyCyle: number, extra = {}) {
     const boardService = this.boardService;
     const request = new pb.SetPWMRequest();
@@ -135,6 +138,7 @@ export class BoardClient implements Board {
       request
     );
   }
+
   async getPWMFrequency(pin: string, extra = {}) {
     const boardService = this.boardService;
     const request = new pb.PWMFrequencyRequest();
@@ -150,6 +154,7 @@ export class BoardClient implements Board {
     >(boardService.pWMFrequency.bind(boardService), request);
     return response.getFrequencyHz();
   }
+
   async setPWMFrequency(pin: string, frequencyHz: number, extra = {}) {
     const boardService = this.boardService;
     const request = new pb.SetPWMFrequencyRequest();
@@ -165,6 +170,7 @@ export class BoardClient implements Board {
       request
     );
   }
+
   async readAnalogReader(analogReader: string, extra = {}) {
     const boardService = this.boardService;
     const request = new pb.ReadAnalogReaderRequest();
@@ -180,6 +186,7 @@ export class BoardClient implements Board {
     >(boardService.readAnalogReader.bind(boardService), request);
     return response.getValue();
   }
+
   async getDigitalInterruptValue(digitalInteruptName: string, extra = {}) {
     const boardService = this.boardService;
     const request = new pb.GetDigitalInterruptValueRequest();

--- a/src/components/board/Client.ts
+++ b/src/components/board/Client.ts
@@ -29,7 +29,7 @@ export class BoardClient implements Board {
   }
 
   private async getRawStatusResponse(extra = {}): Promise<pb.StatusResponse> {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.StatusRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -75,7 +75,7 @@ export class BoardClient implements Board {
   }
 
   async setGPIO(pin: string, high: boolean, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.SetGPIORequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -91,7 +91,7 @@ export class BoardClient implements Board {
   }
 
   async getGPIO(pin: string, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.GetGPIORequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -107,7 +107,7 @@ export class BoardClient implements Board {
   }
 
   async getPWM(pin: string, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.PWMRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -123,7 +123,7 @@ export class BoardClient implements Board {
   }
 
   async setPWM(pin: string, dutyCyle: number, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.SetPWMRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -139,7 +139,7 @@ export class BoardClient implements Board {
   }
 
   async getPWMFrequency(pin: string, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.PWMFrequencyRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -155,7 +155,7 @@ export class BoardClient implements Board {
   }
 
   async setPWMFrequency(pin: string, frequencyHz: number, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.SetPWMFrequencyRequest();
     request.setName(this.name);
     request.setPin(pin);
@@ -171,7 +171,7 @@ export class BoardClient implements Board {
   }
 
   async readAnalogReader(analogReader: string, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.ReadAnalogReaderRequest();
     request.setBoardName(this.name);
     request.setAnalogReaderName(analogReader);
@@ -187,7 +187,7 @@ export class BoardClient implements Board {
   }
 
   async getDigitalInterruptValue(digitalInteruptName: string, extra = {}) {
-    const {boardService} = this;
+    const { boardService } = this;
     const request = new pb.GetDigitalInterruptValueRequest();
     request.setBoardName(this.name);
     request.setDigitalInterruptName(digitalInteruptName);

--- a/src/components/board/Client.ts
+++ b/src/components/board/Client.ts
@@ -1,12 +1,12 @@
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 
-import type { Board } from './Board';
 import { BoardServiceClient } from '../../gen/component/board/v1/board_pb_service';
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 
 import pb from '../../gen/component/board/v1/board_pb';
 import { promisify } from '../../utils';
+import type { Board } from './Board';
 
 /**
  * A gRPC-web client for the Board component.

--- a/src/components/board/Client.ts
+++ b/src/components/board/Client.ts
@@ -36,11 +36,10 @@ export class BoardClient implements Board {
 
     this.options.requestLogger?.(request);
 
-    const response = await promisify<pb.StatusRequest, pb.StatusResponse>(
+    return promisify<pb.StatusRequest, pb.StatusResponse>(
       boardService.status.bind(boardService),
       request
     );
-    return response;
   }
 
   /**

--- a/src/components/camera/Client.ts
+++ b/src/components/camera/Client.ts
@@ -1,10 +1,10 @@
-import type { Camera, MimeType } from './Camera';
 import { CameraServiceClient } from '../../gen/component/camera/v1/camera_pb_service';
 import type { RobotClient } from '../../robot';
 import type { HttpBody } from '../../gen/google/api/httpbody_pb';
 import type { Options } from '../../types';
 import pb from '../../gen/component/camera/v1/camera_pb';
 import { promisify } from '../../utils';
+import type { Camera, MimeType } from './Camera';
 
 const PointCloudPCD: MimeType = 'pointcloud/pcd';
 

--- a/src/components/camera/Client.ts
+++ b/src/components/camera/Client.ts
@@ -29,7 +29,7 @@ export class CameraClient implements Camera {
   }
 
   async getImage(mimeType: MimeType) {
-    const cameraService = this.cameraService;
+    const {cameraService} = this;
     const request = new pb.GetImageRequest();
     request.setName(this.name);
     request.setMimeType(mimeType);
@@ -45,7 +45,7 @@ export class CameraClient implements Camera {
   }
 
   async renderFrame(mimeType: MimeType) {
-    const cameraService = this.cameraService;
+    const {cameraService} = this;
     const request = new pb.GetPointCloudRequest();
     request.setName(this.name);
     request.setMimeType(mimeType);
@@ -61,7 +61,7 @@ export class CameraClient implements Camera {
   }
 
   async getPointCloud() {
-    const cameraService = this.cameraService;
+    const {cameraService} = this;
     const request = new pb.GetPointCloudRequest();
     request.setName(this.name);
     request.setMimeType(PointCloudPCD);
@@ -77,7 +77,7 @@ export class CameraClient implements Camera {
   }
 
   async getProperties() {
-    const cameraService = this.cameraService;
+    const {cameraService} = this;
     const request = new pb.GetPropertiesRequest();
     request.setName(this.name);
 

--- a/src/components/camera/Client.ts
+++ b/src/components/camera/Client.ts
@@ -29,7 +29,7 @@ export class CameraClient implements Camera {
   }
 
   async getImage(mimeType: MimeType) {
-    const {cameraService} = this;
+    const { cameraService } = this;
     const request = new pb.GetImageRequest();
     request.setName(this.name);
     request.setMimeType(mimeType);
@@ -45,7 +45,7 @@ export class CameraClient implements Camera {
   }
 
   async renderFrame(mimeType: MimeType) {
-    const {cameraService} = this;
+    const { cameraService } = this;
     const request = new pb.GetPointCloudRequest();
     request.setName(this.name);
     request.setMimeType(mimeType);
@@ -61,7 +61,7 @@ export class CameraClient implements Camera {
   }
 
   async getPointCloud() {
-    const {cameraService} = this;
+    const { cameraService } = this;
     const request = new pb.GetPointCloudRequest();
     request.setName(this.name);
     request.setMimeType(PointCloudPCD);
@@ -77,7 +77,7 @@ export class CameraClient implements Camera {
   }
 
   async getProperties() {
-    const {cameraService} = this;
+    const { cameraService } = this;
     const request = new pb.GetPropertiesRequest();
     request.setName(this.name);
 

--- a/src/components/encoder/Client.ts
+++ b/src/components/encoder/Client.ts
@@ -27,7 +27,7 @@ export class EncoderClient implements Encoder {
   }
 
   async resetPosition(extra = {}) {
-    const encoderService = this.encoderService;
+    const {encoderService} = this;
     const request = new encoderApi.ResetPositionRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -41,7 +41,7 @@ export class EncoderClient implements Encoder {
   }
 
   async getProperties(extra = {}) {
-    const encoderService = this.encoderService;
+    const {encoderService} = this;
     const request = new encoderApi.GetPropertiesRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -59,7 +59,7 @@ export class EncoderClient implements Encoder {
     positionType: PositionType = PositionType.POSITION_TYPE_UNSPECIFIED,
     extra = {}
   ) {
-    const encoderService = this.encoderService;
+    const {encoderService} = this;
     const request = new encoderApi.GetPositionRequest();
     request.setName(this.name);
     request.setPositionType(positionType);

--- a/src/components/encoder/Client.ts
+++ b/src/components/encoder/Client.ts
@@ -27,7 +27,7 @@ export class EncoderClient implements Encoder {
   }
 
   async resetPosition(extra = {}) {
-    const {encoderService} = this;
+    const { encoderService } = this;
     const request = new encoderApi.ResetPositionRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -41,7 +41,7 @@ export class EncoderClient implements Encoder {
   }
 
   async getProperties(extra = {}) {
-    const {encoderService} = this;
+    const { encoderService } = this;
     const request = new encoderApi.GetPropertiesRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -59,7 +59,7 @@ export class EncoderClient implements Encoder {
     positionType: PositionType = PositionType.POSITION_TYPE_UNSPECIFIED,
     extra = {}
   ) {
-    const {encoderService} = this;
+    const { encoderService } = this;
     const request = new encoderApi.GetPositionRequest();
     request.setName(this.name);
     request.setPositionType(positionType);

--- a/src/components/encoder/Client.ts
+++ b/src/components/encoder/Client.ts
@@ -1,10 +1,10 @@
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import type { RobotClient } from '../../robot';
-import type { Encoder } from './Encoder';
 import { EncoderServiceClient } from '../../gen/component/encoder/v1/encoder_pb_service';
 import { type Options, PositionType } from '../../types';
 import encoderApi from '../../gen/component/encoder/v1/encoder_pb';
 import { promisify } from '../../utils';
+import type { Encoder } from './Encoder';
 
 /**
  * A gRPC-web client for the Encoder component.

--- a/src/components/motor/Client.ts
+++ b/src/components/motor/Client.ts
@@ -1,10 +1,10 @@
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import type { RobotClient } from '../../robot';
-import type { Motor } from './Motor';
 import { MotorServiceClient } from '../../gen/component/motor/v1/motor_pb_service';
 import type { Options } from '../../types';
 import motorApi from '../../gen/component/motor/v1/motor_pb';
 import { promisify } from '../../utils';
+import type { Motor } from './Motor';
 
 /**
  * A gRPC-web client for the Motor component.

--- a/src/components/motor/Client.ts
+++ b/src/components/motor/Client.ts
@@ -27,7 +27,7 @@ export class MotorClient implements Motor {
   }
 
   async setPower(power: number, extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.SetPowerRequest();
     request.setName(this.name);
     request.setPowerPct(power);
@@ -42,7 +42,7 @@ export class MotorClient implements Motor {
   }
 
   async goFor(rpm: number, revolutions: number, extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.GoForRequest();
     request.setName(this.name);
     request.setRpm(rpm);
@@ -58,7 +58,7 @@ export class MotorClient implements Motor {
   }
 
   async goTo(rpm: number, positionRevolutions: number, extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.GoToRequest();
     request.setName(this.name);
     request.setRpm(rpm);
@@ -74,7 +74,7 @@ export class MotorClient implements Motor {
   }
 
   async resetZeroPosition(offset: number, extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.ResetZeroPositionRequest();
     request.setName(this.name);
     request.setOffset(offset);
@@ -89,7 +89,7 @@ export class MotorClient implements Motor {
   }
 
   async stop(extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.StopRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -103,7 +103,7 @@ export class MotorClient implements Motor {
   }
 
   async getProperties(extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.GetPropertiesRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -118,7 +118,7 @@ export class MotorClient implements Motor {
   }
 
   async getPosition(extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.GetPositionRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -133,7 +133,7 @@ export class MotorClient implements Motor {
   }
 
   async isPowered(extra = {}) {
-    const {motorService} = this;
+    const { motorService } = this;
     const request = new motorApi.IsPoweredRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/motor/Client.ts
+++ b/src/components/motor/Client.ts
@@ -27,7 +27,7 @@ export class MotorClient implements Motor {
   }
 
   async setPower(power: number, extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.SetPowerRequest();
     request.setName(this.name);
     request.setPowerPct(power);
@@ -42,7 +42,7 @@ export class MotorClient implements Motor {
   }
 
   async goFor(rpm: number, revolutions: number, extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.GoForRequest();
     request.setName(this.name);
     request.setRpm(rpm);
@@ -58,7 +58,7 @@ export class MotorClient implements Motor {
   }
 
   async goTo(rpm: number, positionRevolutions: number, extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.GoToRequest();
     request.setName(this.name);
     request.setRpm(rpm);
@@ -74,7 +74,7 @@ export class MotorClient implements Motor {
   }
 
   async resetZeroPosition(offset: number, extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.ResetZeroPositionRequest();
     request.setName(this.name);
     request.setOffset(offset);
@@ -89,7 +89,7 @@ export class MotorClient implements Motor {
   }
 
   async stop(extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.StopRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -103,7 +103,7 @@ export class MotorClient implements Motor {
   }
 
   async getProperties(extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.GetPropertiesRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -118,7 +118,7 @@ export class MotorClient implements Motor {
   }
 
   async getPosition(extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.GetPositionRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -133,7 +133,7 @@ export class MotorClient implements Motor {
   }
 
   async isPowered(extra = {}) {
-    const motorService = this.motorService;
+    const {motorService} = this;
     const request = new motorApi.IsPoweredRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/movementsensor/Client.ts
+++ b/src/components/movementsensor/Client.ts
@@ -1,11 +1,11 @@
 import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import type { RobotClient } from '../../robot';
-import type { MovementSensor } from './MovementSensor';
 import { SensorClient } from '../sensor';
 import { MovementSensorServiceClient } from '../../gen/component/movementsensor/v1/movementsensor_pb_service';
 import type { Options } from '../../types';
 import pb from '../../gen/component/movementsensor/v1/movementsensor_pb';
 import { promisify, decodeVector3D } from '../../utils';
+import type { MovementSensor } from './MovementSensor';
 
 /**
  * A gRPC-web client for the MovementSensor component.

--- a/src/components/movementsensor/Client.ts
+++ b/src/components/movementsensor/Client.ts
@@ -30,7 +30,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getLinearVelocity(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetLinearVelocityRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -54,7 +54,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getAngularVelocity(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetAngularVelocityRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -78,7 +78,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getCompassHeading(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetCompassHeadingRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -97,7 +97,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getOrientation(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetOrientationRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -126,7 +126,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getPosition(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetPositionRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -151,7 +151,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getProperties(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetPropertiesRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -174,7 +174,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getAccuracy(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetAccuracyRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -195,7 +195,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getLinearAcceleration(extra = {}) {
-    const {movementsensorService} = this;
+    const { movementsensorService } = this;
     const request = new pb.GetLinearAccelerationRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/movementsensor/Client.ts
+++ b/src/components/movementsensor/Client.ts
@@ -30,7 +30,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getLinearVelocity(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetLinearVelocityRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -54,7 +54,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getAngularVelocity(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetAngularVelocityRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -78,7 +78,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getCompassHeading(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetCompassHeadingRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -97,7 +97,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getOrientation(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetOrientationRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -126,7 +126,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getPosition(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetPositionRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -151,7 +151,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getProperties(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetPropertiesRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -174,7 +174,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getAccuracy(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetAccuracyRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));
@@ -195,7 +195,7 @@ export class MovementSensorClient implements MovementSensor {
   }
 
   async getLinearAcceleration(extra = {}) {
-    const movementsensorService = this.movementsensorService;
+    const {movementsensorService} = this;
     const request = new pb.GetLinearAccelerationRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/sensor/Client.ts
+++ b/src/components/sensor/Client.ts
@@ -29,7 +29,7 @@ export class SensorClient implements Sensor {
   }
 
   async getReadings(extra = {}) {
-    const sensorService = this.sensorService;
+    const {sensorService} = this;
     const request = new sensorApi.GetReadingsRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/sensor/Client.ts
+++ b/src/components/sensor/Client.ts
@@ -29,7 +29,7 @@ export class SensorClient implements Sensor {
   }
 
   async getReadings(extra = {}) {
-    const {sensorService} = this;
+    const { sensorService } = this;
     const request = new sensorApi.GetReadingsRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/components/sensor/Client.ts
+++ b/src/components/sensor/Client.ts
@@ -2,11 +2,11 @@ import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
-import type { Sensor } from './Sensor';
 import { SensorServiceClient } from '../../gen/component/sensor/v1/sensor_pb_service';
 
 import { promisify } from '../../utils';
 import sensorApi from '../../gen/component/sensor/v1/sensor_pb';
+import type { Sensor } from './Sensor';
 
 /**
  * A gRPC-web client for the Sensor component.

--- a/src/components/sensor/Client.ts
+++ b/src/components/sensor/Client.ts
@@ -27,6 +27,7 @@ export class SensorClient implements Sensor {
   private get sensorService() {
     return this.client;
   }
+
   async getReadings(extra = {}) {
     const sensorService = this.sensorService;
     const request = new sensorApi.GetReadingsRequest();

--- a/src/extra/stream/Client.test.ts
+++ b/src/extra/stream/Client.test.ts
@@ -2,8 +2,8 @@
 
 import { describe, expect, test } from 'vitest';
 import { RobotClient } from '../../robot';
-import { StreamClient } from './Client';
 import { events } from '../../events';
+import { StreamClient } from './Client';
 
 describe('StreamClient', () => {
   test('webrtc track will cause the client to emit an event', () =>

--- a/src/extra/stream/Client.test.ts
+++ b/src/extra/stream/Client.test.ts
@@ -7,14 +7,14 @@ import { events } from '../../events';
 
 describe('StreamClient', () => {
   test('webrtc track will cause the client to emit an event', () =>
-    new Promise((done) => {
+    new Promise<void>((done) => {
       const host = 'fakeServiceHost';
       const client = new RobotClient(host);
       const streamClient = new StreamClient(client);
 
       streamClient.on('track', (data) => {
         expect((data as { mock: true }).mock).eq(true);
-        done(undefined);
+        done();
       });
 
       events.emit('track', { mock: true });

--- a/src/extra/stream/Client.ts
+++ b/src/extra/stream/Client.ts
@@ -1,10 +1,10 @@
 import { EventDispatcher, events } from '../../events';
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
-import type { Stream } from './Stream';
 import { StreamServiceClient } from '../../gen/proto/stream/v1/stream_pb_service';
 import pb from '../../gen/proto/stream/v1/stream_pb';
 import { promisify } from '../../utils';
+import type { Stream } from './Stream';
 
 /*
  * Returns a valid SDP video/audio track name as defined in RFC 4566 (https://www.rfc-editor.org/rfc/rfc4566)

--- a/src/extra/stream/Client.ts
+++ b/src/extra/stream/Client.ts
@@ -10,7 +10,7 @@ import { promisify } from '../../utils';
  * Returns a valid SDP video/audio track name as defined in RFC 4566 (https://www.rfc-editor.org/rfc/rfc4566)
  * where track names should not include colons.
  */
-const getValidSDPTrackName = function (name: string) {
+const getValidSDPTrackName = (name: string) => {
   return name.replaceAll(':', '+');
 };
 
@@ -51,7 +51,7 @@ export class StreamClient extends EventDispatcher implements Stream {
         streamService.addStream.bind(streamService),
         request
       );
-    } catch (error) {
+    } catch {
       // Try again with just the resource name
       request.setName(name);
       this.options.requestLogger?.(request);
@@ -73,7 +73,7 @@ export class StreamClient extends EventDispatcher implements Stream {
         streamService.removeStream.bind(streamService),
         request
       );
-    } catch (e) {
+    } catch {
       // Try again with just the resource name
       request.setName(name);
       this.options.requestLogger?.(request);

--- a/src/extra/stream/Client.ts
+++ b/src/extra/stream/Client.ts
@@ -41,7 +41,7 @@ export class StreamClient extends EventDispatcher implements Stream {
   }
 
   async add(name: string) {
-    const streamService = this.streamService;
+    const {streamService} = this;
     const request = new pb.AddStreamRequest();
     const valName = getValidSDPTrackName(name);
     request.setName(valName);
@@ -63,7 +63,7 @@ export class StreamClient extends EventDispatcher implements Stream {
   }
 
   async remove(name: string) {
-    const streamService = this.streamService;
+    const {streamService} = this;
     const request = new pb.RemoveStreamRequest();
     const valName = getValidSDPTrackName(name);
     request.setName(valName);

--- a/src/extra/stream/Client.ts
+++ b/src/extra/stream/Client.ts
@@ -41,7 +41,7 @@ export class StreamClient extends EventDispatcher implements Stream {
   }
 
   async add(name: string) {
-    const {streamService} = this;
+    const { streamService } = this;
     const request = new pb.AddStreamRequest();
     const valName = getValidSDPTrackName(name);
     request.setName(valName);
@@ -63,7 +63,7 @@ export class StreamClient extends EventDispatcher implements Stream {
   }
 
   async remove(name: string) {
-    const {streamService} = this;
+    const { streamService } = this;
     const request = new pb.RemoveStreamRequest();
     const valName = getValidSDPTrackName(name);
     request.setName(valName);

--- a/src/robot/Client.ts
+++ b/src/robot/Client.ts
@@ -1,15 +1,15 @@
 /* eslint-disable max-classes-per-file */
 import type { Credentials, DialOptions } from '@viamrobotics/rpc/src/dial';
-import type { Robot } from './Robot';
+import type { Duration } from 'google-protobuf/google/protobuf/duration_pb';
+import { dialDirect, dialWebRTC } from '@viamrobotics/rpc';
+import type { grpc } from '@improbable-eng/grpc-web';
 import proto from '../gen/robot/v1/robot_pb';
 import type {
   PoseInFrame,
   ResourceName,
   Transform,
 } from '../gen/common/v1/common_pb';
-import type { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import { promisify } from '../utils';
-import { dialDirect, dialWebRTC } from '@viamrobotics/rpc';
 import { ArmServiceClient } from '../gen/component/arm/v1/arm_pb_service';
 import { BaseServiceClient } from '../gen/component/base/v1/base_pb_service';
 import { BoardServiceClient } from '../gen/component/board/v1/board_pb_service';
@@ -26,10 +26,10 @@ import { RobotServiceClient } from '../gen/robot/v1/robot_pb_service';
 import { SLAMServiceClient } from '../gen/service/slam/v1/slam_pb_service';
 import { SensorsServiceClient } from '../gen/service/sensors/v1/sensors_pb_service';
 import { ServoServiceClient } from '../gen/component/servo/v1/servo_pb_service';
-import SessionManager from './SessionManager';
 import { VisionServiceClient } from '../gen/service/vision/v1/vision_pb_service';
 import { events } from '../events';
-import type { grpc } from '@improbable-eng/grpc-web';
+import SessionManager from './SessionManager';
+import type { Robot } from './Robot';
 
 interface WebRTCOptions {
   enabled: boolean;

--- a/src/robot/Client.ts
+++ b/src/robot/Client.ts
@@ -339,7 +339,7 @@ export class RobotClient implements Robot {
         this.transportFactory = webRTCConn.transportFactory;
 
         webRTCConn.peerConnection.ontrack = (event) => {
-          const eventStream = event.streams[0];
+          const [eventStream] = event.streams;
           if (!eventStream) {
             events.emit('track', event);
             throw new Error('expected event stream to exist');
@@ -450,7 +450,7 @@ export class RobotClient implements Robot {
   // OPERATIONS
 
   async getOperations() {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.GetOperationsRequest();
     const response = await promisify<
       proto.GetOperationsRequest,
@@ -460,7 +460,7 @@ export class RobotClient implements Robot {
   }
 
   async cancelOperation(id: string) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.CancelOperationRequest();
     request.setId(id);
     await promisify<
@@ -470,7 +470,7 @@ export class RobotClient implements Robot {
   }
 
   async blockForOperation(id: string) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.BlockForOperationRequest();
     request.setId(id);
     await promisify<
@@ -480,7 +480,7 @@ export class RobotClient implements Robot {
   }
 
   async stopAll() {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.StopAllRequest();
     await promisify<proto.StopAllRequest, proto.StopAllResponse>(
       robotService.stopAll.bind(robotService),
@@ -491,7 +491,7 @@ export class RobotClient implements Robot {
   // FRAME SYSTEM
 
   async frameSystemConfig(transforms: Transform[]) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.FrameSystemConfigRequest();
     request.setSupplementalTransformsList(transforms);
     const response = await promisify<
@@ -506,7 +506,7 @@ export class RobotClient implements Robot {
     destination: string,
     supplementalTransforms: Transform[]
   ) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.TransformPoseRequest();
     request.setSource(source);
     request.setDestination(destination);
@@ -529,7 +529,7 @@ export class RobotClient implements Robot {
     source: string,
     destination: string
   ) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.TransformPCDRequest();
     request.setPointCloudPcd(pointCloudPCD);
     request.setSource(source);
@@ -544,7 +544,7 @@ export class RobotClient implements Robot {
   // DISCOVERY
 
   async discoverComponents(queries: proto.DiscoveryQuery[]) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.DiscoverComponentsRequest();
     request.setQueriesList(queries);
     const response = await promisify<
@@ -557,7 +557,7 @@ export class RobotClient implements Robot {
   // RESOURCES
 
   async resourceNames() {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.ResourceNamesRequest();
     const response = await promisify<
       proto.ResourceNamesRequest,
@@ -567,7 +567,7 @@ export class RobotClient implements Robot {
   }
 
   async resourceRPCSubtypes() {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.ResourceRPCSubtypesRequest();
     const response = await promisify<
       proto.ResourceRPCSubtypesRequest,
@@ -579,7 +579,7 @@ export class RobotClient implements Robot {
   // STATUS
 
   async getStatus(resourceNames: ResourceName[]) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.GetStatusRequest();
     request.setResourceNamesList(resourceNames);
     const response = await promisify<
@@ -590,7 +590,7 @@ export class RobotClient implements Robot {
   }
 
   async streamStatus(resourceNames: ResourceName[], duration: Duration) {
-    const robotService = this.robotService;
+    const { robotService } = this;
     const request = new proto.StreamStatusRequest();
     request.setResourceNamesList(resourceNames);
     request.setEvery(duration);

--- a/src/robot/Robot.ts
+++ b/src/robot/Robot.ts
@@ -1,9 +1,9 @@
+import type { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import type {
   PoseInFrame,
   ResourceName,
   Transform,
 } from '../gen/common/v1/common_pb';
-import type { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import type { Extra } from '../types';
 import type proto from '../gen/robot/v1/robot_pb';
 

--- a/src/robot/SessionManager.test.ts
+++ b/src/robot/SessionManager.test.ts
@@ -3,8 +3,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { ConnectionClosedError } from '@viamrobotics/rpc';
 import { FakeTransportBuilder } from '@improbable-eng/grpc-web-fake-transport';
-import { RobotServiceClient } from '../gen/robot/v1/robot_pb_service';
 import { grpc } from '@improbable-eng/grpc-web';
+import { RobotServiceClient } from '../gen/robot/v1/robot_pb_service';
 
 import SessionManager from './SessionManager';
 

--- a/src/robot/SessionManager.ts
+++ b/src/robot/SessionManager.ts
@@ -112,7 +112,7 @@ export default class SessionManager {
       const url = window.URL.createObjectURL(timeoutBlob);
       worker = new Worker(url);
       URL.revokeObjectURL(url);
-      worker.onmessage = function () {
+      worker.onmessage = () => {
         doHeartbeat();
       };
     }
@@ -143,7 +143,7 @@ export default class SessionManager {
         new grpc.Metadata(),
         (err, resp) => {
           if (err) {
-            if ((err as ServiceError).code === grpc.Code.Unimplemented) {
+            if (err.code === grpc.Code.Unimplemented) {
               console.error('sessions unsupported; will not try again');
               this.sessionsSupported = false;
               this.startResolve?.();

--- a/src/robot/SessionManager.ts
+++ b/src/robot/SessionManager.ts
@@ -83,17 +83,15 @@ export default class SessionManager {
         sendHeartbeatReq,
         new grpc.Metadata(),
         (err) => {
-          if (err) {
-            if (ConnectionClosedError.isError(err)) {
-              /*
-               * We assume the connection closing will cause getSessionMetadata to be
-               * called again by way of a reset.
-               */
-              this.reset();
-              return;
-            }
-            // Otherwise we want to continue in case it was just a blip
+          if (err && ConnectionClosedError.isError(err)) {
+            /*
+             * We assume the connection closing will cause getSessionMetadata to be
+             * called again by way of a reset.
+             */
+            this.reset();
+            return;
           }
+          // Otherwise we want to continue in case it was just a blip
           if (worker) {
             worker.postMessage(this.heartbeatIntervalMs);
           } else {

--- a/src/robot/SessionManager.ts
+++ b/src/robot/SessionManager.ts
@@ -1,11 +1,11 @@
+import { ConnectionClosedError } from '@viamrobotics/rpc';
+import { grpc } from '@improbable-eng/grpc-web';
 import {
   RobotServiceClient,
   type ServiceError,
 } from '../gen/robot/v1/robot_pb_service';
-import { ConnectionClosedError } from '@viamrobotics/rpc';
-import SessionTransport from './SessionTransport';
-import { grpc } from '@improbable-eng/grpc-web';
 import robotApi from '../gen/robot/v1/robot_pb';
+import SessionTransport from './SessionTransport';
 
 const timeoutBlob = new Blob(
   [

--- a/src/robot/SessionTransport.ts
+++ b/src/robot/SessionTransport.ts
@@ -58,14 +58,15 @@ export default class SessionTransport implements grpc.Transport {
     this.sessionManager
       .getSessionMetadata()
       .then((md) => {
+        // eslint-disable-next-line unicorn/no-array-for-each
         md.forEach((key: string, values: string | string[]) => {
           metadata.set(key, values);
         });
         this.transport.start(metadata);
         this.mdPromResolve?.();
       })
-      .catch((err) => {
-        this.opts.onEnd(err);
+      .catch((error) => {
+        this.opts.onEnd(error);
       });
   }
 

--- a/src/robot/SessionTransport.ts
+++ b/src/robot/SessionTransport.ts
@@ -17,13 +17,13 @@ export default class SessionTransport implements grpc.Transport {
   ) {
     const actualOnEnd = opts.onEnd;
     opts.onEnd = (err?: Error) => {
-      if (err && err instanceof GRPCError) {
-        if (
-          err.code === grpc.Code.InvalidArgument &&
-          err.grpcMessage === 'SESSION_EXPIRED'
-        ) {
-          this.sessionManager.reset();
-        }
+      if (
+        err &&
+        err instanceof GRPCError &&
+        err.code === grpc.Code.InvalidArgument &&
+        err.grpcMessage === 'SESSION_EXPIRED'
+      ) {
+        this.sessionManager.reset();
       }
       actualOnEnd(err);
     };

--- a/src/robot/SessionTransport.ts
+++ b/src/robot/SessionTransport.ts
@@ -1,6 +1,6 @@
 import { GRPCError } from '@viamrobotics/rpc';
-import type SessionManager from './SessionManager';
 import { grpc } from '@improbable-eng/grpc-web';
+import type SessionManager from './SessionManager';
 
 export default class SessionTransport implements grpc.Transport {
   private readonly opts: grpc.TransportOptions;

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -90,7 +90,9 @@ export type DialConf = DialDirectConf | DialWebRTCConf;
 const isDialWebRTCConf = (value: DialConf): value is DialWebRTCConf => {
   const conf = value as DialWebRTCConf;
 
-  if (typeof conf.signalingAddress !== 'string') return false;
+  if (typeof conf.signalingAddress !== 'string') {
+    return false;
+  }
 
   return !conf.iceServers || conf.iceServers instanceof Array;
 };
@@ -118,7 +120,7 @@ export const createRobotClient = async (
   if (isDialWebRTCConf(conf)) {
     try {
       client = await dialWebRTC(conf);
-    } catch (err) {
+    } catch {
       // eslint-disable-next-line no-console
       console.debug('failed to connect via WebRTC...');
     }
@@ -127,7 +129,7 @@ export const createRobotClient = async (
   if (!client) {
     try {
       client = await dialDirect(conf);
-    } catch (err) {
+    } catch {
       // eslint-disable-next-line no-console
       console.debug('failed to connect via gRPC...');
     }

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -60,7 +60,7 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
   console.debug('dialing via WebRTC...');
 
   const impliedURL = conf.host;
-  const signalingAddress = conf.signalingAddress;
+  const {signalingAddress} = conf;
   const iceServers = conf.iceServers ?? [];
 
   const rtcConfig = { iceServers };
@@ -94,7 +94,7 @@ const isDialWebRTCConf = (value: DialConf): value is DialWebRTCConf => {
     return false;
   }
 
-  return !conf.iceServers || conf.iceServers instanceof Array;
+  return !conf.iceServers || Array.isArray(conf.iceServers);
 };
 
 /**

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -60,7 +60,7 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
   console.debug('dialing via WebRTC...');
 
   const impliedURL = conf.host;
-  const {signalingAddress} = conf;
+  const { signalingAddress } = conf;
   const iceServers = conf.iceServers ?? [];
 
   const rtcConfig = { iceServers };

--- a/src/services/datamanager/client.ts
+++ b/src/services/datamanager/client.ts
@@ -23,7 +23,7 @@ export class DataManagerClient implements DataManager {
   }
 
   async Sync(extra = {}) {
-    const datamanagerService = this.datamanagerService;
+    const {datamanagerService} = this;
     const request = new pb.SyncRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/services/datamanager/client.ts
+++ b/src/services/datamanager/client.ts
@@ -23,7 +23,7 @@ export class DataManagerClient implements DataManager {
   }
 
   async Sync(extra = {}) {
-    const {datamanagerService} = this;
+    const { datamanagerService } = this;
     const request = new pb.SyncRequest();
     request.setName(this.name);
     request.setExtra(Struct.fromJavaScript(extra));

--- a/src/services/motion/Client.ts
+++ b/src/services/motion/Client.ts
@@ -21,7 +21,6 @@ import pb from '../../gen/service/motion/v1/motion_pb';
 import { type MotionConstraints, encodeConstraints } from './types';
 import type { Motion } from './Motion';
 
-
 /**
  * A gRPC-web client for a Motion service.
  *
@@ -49,7 +48,7 @@ export class MotionClient implements Motion {
     constraints?: MotionConstraints,
     extra = {}
   ) {
-    const {service} = this;
+    const { service } = this;
 
     const request = new pb.MoveRequest();
     request.setName(this.name);
@@ -79,7 +78,7 @@ export class MotionClient implements Motion {
     slamServiceName: ResourceName,
     extra = {}
   ) {
-    const {service} = this;
+    const { service } = this;
 
     const request = new pb.MoveOnMapRequest();
     request.setName(this.name);
@@ -104,7 +103,7 @@ export class MotionClient implements Motion {
     worldState?: WorldState,
     extra = {}
   ) {
-    const {service} = this;
+    const { service } = this;
 
     const request = new pb.MoveSingleComponentRequest();
     request.setName(this.name);
@@ -131,7 +130,7 @@ export class MotionClient implements Motion {
     supplementalTransforms: Transform[],
     extra = {}
   ) {
-    const {service} = this;
+    const { service } = this;
 
     const request = new pb.GetPoseRequest();
     request.setName(this.name);

--- a/src/services/motion/Client.ts
+++ b/src/services/motion/Client.ts
@@ -1,3 +1,4 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import type { RobotClient } from '../../robot';
 import { MotionServiceClient } from '../../gen/service/motion/v1/motion_pb_service';
 import type {
@@ -8,7 +9,6 @@ import type {
   Transform,
   WorldState,
 } from '../../types';
-import { type MotionConstraints, encodeConstraints } from './types';
 import {
   promisify,
   encodeResourceName,
@@ -17,10 +17,10 @@ import {
   encodeWorldState,
   encodeTransform,
 } from '../../utils';
+import pb from '../../gen/service/motion/v1/motion_pb';
+import { type MotionConstraints, encodeConstraints } from './types';
 import type { Motion } from './Motion';
 
-import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
-import pb from '../../gen/service/motion/v1/motion_pb';
 
 /**
  * A gRPC-web client for a Motion service.

--- a/src/services/motion/Client.ts
+++ b/src/services/motion/Client.ts
@@ -49,7 +49,7 @@ export class MotionClient implements Motion {
     constraints?: MotionConstraints,
     extra = {}
   ) {
-    const service = this.service;
+    const {service} = this;
 
     const request = new pb.MoveRequest();
     request.setName(this.name);
@@ -79,7 +79,7 @@ export class MotionClient implements Motion {
     slamServiceName: ResourceName,
     extra = {}
   ) {
-    const service = this.service;
+    const {service} = this;
 
     const request = new pb.MoveOnMapRequest();
     request.setName(this.name);
@@ -104,7 +104,7 @@ export class MotionClient implements Motion {
     worldState?: WorldState,
     extra = {}
   ) {
-    const service = this.service;
+    const {service} = this;
 
     const request = new pb.MoveSingleComponentRequest();
     request.setName(this.name);
@@ -131,7 +131,7 @@ export class MotionClient implements Motion {
     supplementalTransforms: Transform[],
     extra = {}
   ) {
-    const service = this.service;
+    const {service} = this;
 
     const request = new pb.GetPoseRequest();
     request.setName(this.name);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import type { ServiceError } from './gen/robot/v1/robot_pb_service';
 import { grpc } from '@improbable-eng/grpc-web';
+import type { ServiceError } from './gen/robot/v1/robot_pb_service';
 import common from './gen/common/v1/common_pb';
 import type { Vector3D } from './types';
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,10 +11,10 @@ type ServiceFunc<Req, Resp> = (
   callback: Callback<Resp>
 ) => void;
 
-export const promisify = function <Req, Resp>(
+export const promisify = <Req, Resp>(
   func: ServiceFunc<Req, Resp>,
   request: Req
-): Promise<Resp> {
+): Promise<Resp> => {
   return new Promise((resolve, reject) => {
     func(request, new grpc.Metadata(), (error, response) => {
       if (error) {
@@ -29,7 +29,7 @@ export const promisify = function <Req, Resp>(
 };
 
 /** Convert a 3D Vector POJO to a Protobuf Datatype */
-export const encodeVector3D = function (value: Vector3D): common.Vector3 {
+export const encodeVector3D = (value: Vector3D): common.Vector3 => {
   const proto = new common.Vector3();
 
   proto.setX(value.x);
@@ -40,7 +40,7 @@ export const encodeVector3D = function (value: Vector3D): common.Vector3 {
 };
 
 /** Convert a 3D Vector Protobuf Datatype to a POJO */
-export const decodeVector3D = function (proto: common.Vector3): Vector3D {
+export const decodeVector3D = (proto: common.Vector3): Vector3D => {
   return {
     x: proto.getX(),
     y: proto.getY(),


### PR DESCRIPTION
## Overview

This PR picks off all the "minor" linting warnings after merging #52. That means anything that was purely stylistic or fixable via `eslint --fix`.

There are about 50 remaining warnings, mostly from `unicorn/filename-case` and various `@typescript-eslint` rules that are going to be more involved to fix.

## Test plan

Due to number of files touched, IMO this PR requires smoke testing with actual hardware. The riskiest move here is _probably_ the import reordering, since it could cause changes in behavior if we have any problematic circular dependencies.