### PR TITLE
RSDK-3015 - Fix streamStatus

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ export {
   type DialDirectConf,
   type DialWebRTCConf,
   RobotClient,
+  RobotStatusStream,
   createRobotClient,
 } from './robot';
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,8 +15,8 @@ export {
   type DialConf,
   type DialDirectConf,
   type DialWebRTCConf,
+  type RobotStatusStream,
   RobotClient,
-  RobotStatusStream,
   createRobotClient,
 } from './robot';
 /**

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,0 +1,24 @@
+import { EventDispatcher } from './events';
+import type { ResponseStream } from './gen/robot/v1/robot_pb_service';
+
+export class IResponseStream<T> extends EventDispatcher {
+  private stream: ResponseStream<any>;
+
+  constructor(stream: ResponseStream<any>) {
+    super();
+    this.stream = stream;
+  }
+
+  override on(
+    type: string,
+    handler: (message: any) => void
+  ): IResponseStream<T> {
+    super.on(type, handler);
+    return this;
+  }
+
+  cancel(): void {
+    this.listeners = {};
+    this.stream.cancel();
+  }
+}

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,10 +1,10 @@
 import { EventDispatcher } from './events';
-import type { ResponseStream as ProtoResponseStream } from './gen/robot/v1/robot_pb_service';
+import type { ResponseStream } from './gen/robot/v1/robot_pb_service';
 
-export class ResponseStream<T> extends EventDispatcher {
-  private stream: ProtoResponseStream<any>;
+export class ViamResponseStream<T> extends EventDispatcher {
+  private stream: ResponseStream<any>;
 
-  constructor(stream: ProtoResponseStream<any>) {
+  constructor(stream: ResponseStream<any>) {
     super();
     this.stream = stream;
   }

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -1,10 +1,10 @@
 import { EventDispatcher } from './events';
-import type { ResponseStream } from './gen/robot/v1/robot_pb_service';
+import type { ResponseStream as ProtoResponseStream } from './gen/robot/v1/robot_pb_service';
 
-export class IResponseStream<T> extends EventDispatcher {
-  private stream: ResponseStream<any>;
+export class ResponseStream<T> extends EventDispatcher {
+  private stream: ProtoResponseStream<any>;
 
-  constructor(stream: ResponseStream<any>) {
+  constructor(stream: ProtoResponseStream<any>) {
     super();
     this.stream = stream;
   }
@@ -12,7 +12,7 @@ export class IResponseStream<T> extends EventDispatcher {
   override on(
     type: string,
     handler: (message: any) => void
-  ): IResponseStream<T> {
+  ): ResponseStream<T> {
     super.on(type, handler);
     return this;
   }

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -1,4 +1,4 @@
-export type { Robot } from './robot/robot';
+export type { Robot, RobotStatusStream } from './robot/robot';
 export { RobotClient } from './robot/client';
 export {
   type DialConf,

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -601,7 +601,7 @@ export class RobotClient implements Robot {
     request.setEvery(duration);
 
     const statusStream = robotService.streamStatus(request);
-    if (statusStream === null) {
+    if (!statusStream) {
       throw new Error('no stream');
     }
     const stream = new IResponseStream<proto.Status[]>(statusStream);

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -23,15 +23,15 @@ import { MotorServiceClient } from '../gen/component/motor/v1/motor_pb_service';
 import { MovementSensorServiceClient } from '../gen/component/movementsensor/v1/movementsensor_pb_service';
 import { NavigationServiceClient } from '../gen/service/navigation/v1/navigation_pb_service';
 import { RobotServiceClient } from '../gen/robot/v1/robot_pb_service';
-import type { ResponseStream, Status } from '../gen/robot/v1/robot_pb_service';
+import type { Status } from '../gen/robot/v1/robot_pb_service';
 import { SLAMServiceClient } from '../gen/service/slam/v1/slam_pb_service';
 import { SensorsServiceClient } from '../gen/service/sensors/v1/sensors_pb_service';
 import { ServoServiceClient } from '../gen/component/servo/v1/servo_pb_service';
 import { VisionServiceClient } from '../gen/service/vision/v1/vision_pb_service';
 import { events } from '../events';
-import { IResponseStream } from '../responses';
+import { ViamResponseStream } from '../responses';
 import SessionManager from './session-manager';
-import type { Robot } from './robot';
+import type { Robot, RobotStatusStream } from './robot';
 
 interface WebRTCOptions {
   enabled: boolean;
@@ -594,7 +594,7 @@ export class RobotClient implements Robot {
   streamStatus(
     resourceNames: ResourceName[],
     duration: Duration
-  ): ResponseStream<proto.Status[]> {
+  ): RobotStatusStream {
     const { robotService } = this;
     const request = new proto.StreamStatusRequest();
     request.setResourceNamesList(resourceNames);
@@ -604,7 +604,7 @@ export class RobotClient implements Robot {
     if (!statusStream) {
       throw new Error('no stream');
     }
-    const stream = new IResponseStream<proto.Status[]>(statusStream);
+    const stream = new ViamResponseStream<proto.Status[]>(statusStream);
     statusStream.on('data', (response: proto.StreamStatusResponse) => {
       stream.emit('data', response.getStatusList());
     });

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -8,6 +8,8 @@ import type { StructType } from '../types';
 import type proto from '../gen/robot/v1/robot_pb';
 import type { ResponseStream } from '../gen/robot/v1/robot_pb_service';
 
+export type RobotStatusStream = ResponseStream<proto.Status[]>;
+
 export interface Robot {
   /**
    * Get the list of operations currently running on the robot.
@@ -143,5 +145,5 @@ export interface Robot {
   streamStatus(
     resourceNames: ResourceName[],
     duration: Duration
-  ): ResponseStream<proto.Status[]>;
+  ): RobotStatusStream;
 }

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -6,6 +6,7 @@ import type {
 } from '../gen/common/v1/common_pb';
 import type { StructType } from '../types';
 import type proto from '../gen/robot/v1/robot_pb';
+import type { ResponseStream } from '../gen/robot/v1/robot_pb_service';
 
 export interface Robot {
   /**
@@ -142,5 +143,5 @@ export interface Robot {
   streamStatus(
     resourceNames: ResourceName[],
     duration: Duration
-  ): Promise<proto.Status[]>;
+  ): ResponseStream<proto.Status[]>;
 }


### PR DESCRIPTION
status stream used to not work at all, reworked so it works? maybe.

pretty open to suggestions as to where I should be putting the new class, and its name, but all it is is a concrete impl of ResponseStream leveraging the existing EventDispatcher class.

tested using the below block
```
  let stream = robot.streamStatus([], new Duration().setNanos(500_000_000));
  stream.on('data', (response: VIAM.robotApi.Status[]) => {
    console.log(response);
  });
  stream.on('status', (newStatus?: { details: unknown }) => {
    console.error('error streaming robot status', newStatus);
  });
  stream.on('end', () => {
    console.error('done streaming robot status');
  });
```