### PR TITLE
RSDK-2403 Expose disableSessions option in DialConf

### DIFF
--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -10,6 +10,7 @@ export interface DialDirectConf {
   authEntity?: string;
   host: string;
   credential?: Credential;
+  disableSessions?: boolean;
 }
 
 /** Check if a url corresponds to a local connection via heuristic */
@@ -25,7 +26,11 @@ const dialDirect = async (conf: DialDirectConf): Promise<RobotClient> => {
     );
   }
 
-  const client = new RobotClient(conf.host);
+  let sessOpts;
+  if (conf.disableSessions) {
+    sessOpts = { disabled: true };
+  }
+  const client = new RobotClient(conf.host, undefined, sessOpts);
 
   let creds;
   if (conf.credential) {
@@ -50,6 +55,7 @@ export interface DialWebRTCConf {
   authEntity?: string;
   host: string;
   credential?: Credential;
+  disableSessions?: boolean;
   // WebRTC
   signalingAddress: string;
   iceServers?: ICEServer[];
@@ -70,7 +76,11 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
     signalingAddress,
     rtcConfig,
   };
-  const client = new RobotClient(impliedURL, clientConf);
+  let sessOpts;
+  if (conf.disableSessions) {
+    sessOpts = { disabled: true };
+  }
+  const client = new RobotClient(impliedURL, clientConf, sessOpts);
 
   let creds;
   if (conf.credential) {


### PR DESCRIPTION
[RSDK-2403](https://viam.atlassian.net/browse/RSDK-2403)

Exposes a new `disableSessions` option in `DialDirectConf` and `DialWebRTConf` that is passed to the `RobotClient` constructor.



[RSDK-2403]: https://viam.atlassian.net/browse/RSDK-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ