### PR TITLE
fix: Update 'exports' in package.json for TypeScript type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "exports": {
     ".": {
       "import": "./dist/main.es.js",
-      "require": "./dist/main.umd.js"
-    }
+      "require": "./dist/main.umd.js",
+      "types": "./dist/main.d.ts"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "npm run build:bundle && npm run build:types && npm run build:copy-dts",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,10 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/main.d.ts",
       "import": "./dist/main.es.js",
-      "require": "./dist/main.umd.js",
-      "types": "./dist/main.d.ts"
-    },
-    "./package.json": "./package.json"
+      "require": "./dist/main.umd.js"
+    }
   },
   "scripts": {
     "build": "npm run build:bundle && npm run build:types && npm run build:copy-dts",


### PR DESCRIPTION
fix: Correct 'exports' field in package.json to align with Node.js v12+ module resolution

In Node.js v12 and later, enhancements were made to the module resolution system via the 'exports' field in package.json. These enhancements provide encapsulation by only allowing consumers to import files explicitly defined in 'exports'. While these changes provide greater control and security over modules, **they've also introduced a need to be explicit with TypeScript type definitions.**

Previously, TypeScript was able to locate type definition files as long as the 'types' field was specified in package.json, regardless of the 'exports' field. This has changed with recent Node.js versions, causing a 'Could not find a declaration file for module' error for TypeScript consumers of the SDK, despite 'types' being correctly defined in package.json.

To resolve this, the 'exports' field in package.json has been updated to include a 'types' entry pointing to the type definitions:

```json
"exports": {
  ".": {
    "import": "./dist/main.es.js",
    "require": "./dist/main.umd.js",
    "types": "./dist/main.d.ts"
  },
  "./package.json": "./package.json"
}
```

This aligns the package with the current module resolution system in Node.js, ensuring TypeScript can correctly locate type definitions.