### PR TITLE
RSDK-3923 Add workflow to publish off-cycle releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,3 +8,9 @@ on:
 jobs:
   test:
     uses: viamrobotics/viam-typescript-sdk/.github/workflows/test.yml@main
+
+  publish_next:
+    needs: test
+    uses: viamrobotics/viam-typescript-sdk/.github/workflows/publish_next.yml@main
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_next.yml
+++ b/.github/workflows/publish_next.yml
@@ -1,0 +1,31 @@
+name: NPM Publish Next
+
+on:
+  workflow_call:
+    secrets:
+        NPM_TOKEN:
+          required: true
+
+jobs:
+  publish_next:
+    if: github.repository_owner == 'viamrobotics'
+    runs-on: [self-hosted, x64]
+    container:
+      image: ghcr.io/viamrobotics/canon:amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Build
+        run: |
+          sudo chown -R testbot .
+          sudo -u testbot bash -lc 'make build'
+
+      - name: Publish
+        uses: JS-DevTools/npm-publish@v2
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: next

--- a/.github/workflows/publish_next.yml
+++ b/.github/workflows/publish_next.yml
@@ -3,8 +3,8 @@ name: NPM Publish Next
 on:
   workflow_call:
     secrets:
-        NPM_TOKEN:
-          required: true
+      NPM_TOKEN:
+        required: true
 
 jobs:
   publish_next:
@@ -24,7 +24,21 @@ jobs:
           sudo chown -R testbot .
           sudo -u testbot bash -lc 'make build'
 
+      - name: Publish (dry run)
+        id: check_new_version
+        uses: JS-DevTools/npm-publish@v2
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          tag: next
+          dry-run: true
+
+      - name: Validate version name
+        if: ${{ steps.check_new_version.outputs.type }}
+        run: |
+          [[ "$(npm pkg get version)" =~ ^\"[0-9]+\.[0-9]+\.[0-9]\-next\.[0-9]+\"$ ]] || exit 1
+
       - name: Publish
+        if: ${{ steps.check_new_version.outputs.type }}
         uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish_next.yml
+++ b/.github/workflows/publish_next.yml
@@ -37,6 +37,8 @@ jobs:
         run: |
           [[ "$(npm pkg get version)" =~ ^\"[0-9]+\.[0-9]+\.[0-9]\-next\.[0-9]+\"$ ]] || exit 1
 
+          # TODO: add custom error message pointing users to bump version with `make bump-next-version`
+
       - name: Publish
         if: ${{ steps.check_new_version.outputs.type }}
         uses: JS-DevTools/npm-publish@v2

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -68,6 +68,8 @@ jobs:
         run: |
           if ${{ contains(steps.current_version.outputs.current_version, 'rc') }} ; then
             npm version prerelease --preid=rc --no-git-tag-version
+          elif ${{ contains(steps.current_version.outputs.current_version, 'next') && inputs.version == 'prepatch' }} ; then
+            npm version prerelease --preid=rc --no-git-tag-version
           else
             npm version ${{ inputs.version }} --preid=rc --no-git-tag-version
           fi

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,12 @@ build-js: $(node_modules) clean-js build-buf
 pack: build
 	npm pack
 
+# bump to the next pre-release version on the `next` distribution tag -
+# run this command if you need to publish an off-cycle release of the sdk
+.PHONY: bump-next-version
+bump-next-version:
+	npm version --no-git-tag-version prerelease --preid=next
+
 # docs targets
 
 .PHONY: clean-docs


### PR DESCRIPTION
Allows off-cycle version to be published to the `next` distribution tag

TODO

* [ ] custom error message
* [ ] test