### PR TITLE
RSDK-2379 Add getStream to stream api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean: clean-js clean-buf clean-docs
 test: $(node_modules) build-buf
 	npm run test
 
-.PHONY: test-watch-js
+.PHONY: test-watch
 test-watch: $(node_modules) build-buf
 	npm run test:watch
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test: $(node_modules) build-buf
 	npm run test
 
 .PHONY: test-watch-js
-test-watch-js: $(node_modules) build-buf
+test-watch: $(node_modules) build-buf
 	npm run test:watch
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ clean: clean-js clean-buf clean-docs
 test: $(node_modules) build-buf
 	npm run test
 
+.PHONY: test-watch-js
+test-watch-js: $(node_modules) build-buf
+	npm run test:watch
+
 .PHONY: lint
 lint: $(node_modules) build-buf
 	npm run lint

--- a/examples/teleop-elm/package-lock.json
+++ b/examples/teleop-elm/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../..": {
       "name": "@viamrobotics/sdk",
-      "version": "0.2.0",
+      "version": "0.2.5-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.37",

--- a/examples/teleop-elm/src/index.js
+++ b/examples/teleop-elm/src/index.js
@@ -18,7 +18,7 @@ async function connectWebRTC() {
 }
 
 function injectMediaStream(eventStream) {
-  console.debug("got media stream");
+  console.debug('got media stream');
 
   const streamName = eventStream.id;
   const streamContainers = document.querySelectorAll(
@@ -58,7 +58,7 @@ connectWebRTC()
       flags: {},
     });
 
-    console.debug("requested media stream");
+    console.debug('requested media stream');
     streams.getStream('cam').then((mediaStream) => {
       injectMediaStream(mediaStream);
     });

--- a/examples/teleop-react/package-lock.json
+++ b/examples/teleop-react/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../..": {
       "name": "@viamrobotics/sdk",
-      "version": "0.2.0",
+      "version": "0.2.5-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.37",

--- a/examples/teleop-react/src/client.ts
+++ b/examples/teleop-react/src/client.ts
@@ -52,35 +52,3 @@ export const getStreamClient = (client: RobotClient): StreamClient => {
 export const getBaseClient = (client: RobotClient): BaseClient => {
   return new BaseClient(client, 'viam_base');
 };
-
-/**
- * Get a stream by name from a StreamClient.
- *
- * @param streamClient - The connected StreamClient.
- * @param name - The name of the camera.
- * @returns A MediaStream object that can be used in a <video>.
- */
-export const getStream = async (
-  streamClient: StreamClient,
-  name: string
-): Promise<MediaStream> => {
-  const streamPromise = new Promise<MediaStream>((resolve, reject) => {
-    const handleTrack = (event: RTCTrackEvent) => {
-      const stream = event.streams[0];
-
-      if (!stream) {
-        streamClient.off('track', handleTrack as (args: unknown) => void);
-        reject(new Error('Recieved track event with no streams'));
-      } else if (stream.id === name) {
-        streamClient.off('track', handleTrack as (args: unknown) => void);
-        resolve(stream);
-      }
-    };
-
-    streamClient.on('track', handleTrack as (args: unknown) => void);
-  });
-
-  await streamClient.add(name);
-
-  return streamPromise;
-};

--- a/examples/teleop-react/src/state.ts
+++ b/examples/teleop-react/src/state.ts
@@ -92,7 +92,8 @@ export const useStream = (
     if (streamClient && okToConnectRef.current) {
       okToConnectRef.current = false;
 
-      getStream(streamClient, cameraName)
+      streamClient
+        .getStream(cameraName)
         .then((mediaStream) => setStream(mediaStream))
         .catch((error: unknown) => {
           console.warn(`Unable to connect to camera ${cameraName}`, error);

--- a/src/extra/stream/client.test.ts
+++ b/src/extra/stream/client.test.ts
@@ -46,4 +46,16 @@ describe('StreamClient', () => {
       fakeStream
     );
   });
+  test('getStream fails when add stream fails', async () => {
+    const error = new Error('could not add stream');
+    StreamServiceClient.prototype.addStream = vi
+      .fn()
+      .mockImplementation((_req, _md, cb) => {
+        cb(error);
+      });
+
+    await expect(streamClient.getStream('fakecam')).rejects.toStrictEqual(
+      error
+    );
+  });
 });

--- a/src/extra/stream/client.test.ts
+++ b/src/extra/stream/client.test.ts
@@ -46,12 +46,16 @@ describe('StreamClient', () => {
         streamClient.emit('track', { streams: [fakeStream] });
       });
 
+    const addStream = vi.spyOn(streamClient, 'add');
     await expect(streamClient.getStream(fakeCamName)).resolves.toStrictEqual(
       fakeStream
     );
+    expect(addStream).toHaveBeenCalledOnce();
+    expect(addStream).toHaveBeenCalledWith(fakeCamName);
   });
 
   test('getStream fails when add stream fails', async () => {
+    const fakeCamName = 'fakecam';
     const error = new Error('could not add stream');
     StreamServiceClient.prototype.addStream = vi
       .fn()
@@ -59,21 +63,28 @@ describe('StreamClient', () => {
         cb(error);
       });
 
-    await expect(streamClient.getStream('fakecam')).rejects.toThrow(error);
+    const addStream = vi.spyOn(streamClient, 'add');
+    await expect(streamClient.getStream(fakeCamName)).rejects.toThrow(error);
+    expect(addStream).toHaveBeenCalledOnce();
+    expect(addStream).toHaveBeenCalledWith(fakeCamName);
   });
 
   test('getStream fails when timeout exceeded', async () => {
+    const fakeCamName = 'fakecam';
     StreamServiceClient.prototype.addStream = vi
       .fn()
       .mockImplementation((_req, _md, cb) => {
         cb(null, {});
       });
 
-    const promise = streamClient.getStream('fakecam');
+    const addStream = vi.spyOn(streamClient, 'add');
+    const promise = streamClient.getStream(fakeCamName);
     vi.runAllTimers();
     await expect(promise).rejects.toThrowError(
       'Did not receive a stream after 5000 ms'
     );
+    expect(addStream).toHaveBeenCalledOnce();
+    expect(addStream).toHaveBeenCalledWith(fakeCamName);
   });
 
   test('getStream can add the same stream twice', async () => {
@@ -86,11 +97,14 @@ describe('StreamClient', () => {
         streamClient.emit('track', { streams: [fakeStream] });
       });
 
+    const addStream = vi.spyOn(streamClient, 'add');
     await expect(streamClient.getStream(fakeCamName)).resolves.toStrictEqual(
       fakeStream
     );
     await expect(streamClient.getStream(fakeCamName)).resolves.toStrictEqual(
       fakeStream
     );
+    expect(addStream).toHaveBeenCalledTimes(2);
+    expect(addStream).toHaveBeenCalledWith(fakeCamName);
   });
 });

--- a/src/extra/stream/client.test.ts
+++ b/src/extra/stream/client.test.ts
@@ -10,14 +10,18 @@ vi.mock('../../gen/proto/stream/v1/stream_pb_service');
 
 import { StreamClient } from './client';
 
-let robotClient: RobotClient;
 let streamClient: StreamClient;
 
 describe('StreamClient', () => {
   beforeEach(() => {
     vi.useFakeTimers();
 
-    robotClient = new RobotClient('fakehost');
+    const fakehost = 'fakehost';
+    RobotClient.prototype.createServiceClient = vi
+      .fn()
+      .mockImplementation(() => new StreamServiceClient(fakehost));
+
+    const robotClient = new RobotClient(fakehost);
     streamClient = new StreamClient(robotClient);
   });
 

--- a/src/extra/stream/client.test.ts
+++ b/src/extra/stream/client.test.ts
@@ -73,4 +73,22 @@ describe('StreamClient', () => {
     vi.runAllTimers();
     await expect(promise).rejects.toThrowError('timed out');
   });
+
+  test('getStream can add the same stream twice', async () => {
+    const fakeCamName = 'fakecam';
+    const fakeStream = { id: fakeCamName };
+    StreamServiceClient.prototype.addStream = vi
+      .fn()
+      .mockImplementation((_req, _md, cb) => {
+        cb(null, {});
+        streamClient.emit('track', { streams: [fakeStream] });
+      });
+
+    await expect(streamClient.getStream(fakeCamName)).resolves.toStrictEqual(
+      fakeStream
+    );
+    await expect(streamClient.getStream(fakeCamName)).resolves.toStrictEqual(
+      fakeStream
+    );
+  });
 });

--- a/src/extra/stream/client.test.ts
+++ b/src/extra/stream/client.test.ts
@@ -71,7 +71,9 @@ describe('StreamClient', () => {
 
     const promise = streamClient.getStream('fakecam');
     vi.runAllTimers();
-    await expect(promise).rejects.toThrowError('timed out');
+    await expect(promise).rejects.toThrowError(
+      'Did not receive a stream after 5000 ms'
+    );
   });
 
   test('getStream can add the same stream twice', async () => {

--- a/src/extra/stream/client.test.ts
+++ b/src/extra/stream/client.test.ts
@@ -2,8 +2,12 @@
 
 import { vi, beforeEach, afterEach, describe, expect, test } from 'vitest';
 import { RobotClient } from '../../robot';
+vi.mock('../../robot/client');
+
 import { events } from '../../events';
 import { StreamServiceClient } from '../../gen/proto/stream/v1/stream_pb_service';
+vi.mock('../../gen/proto/stream/v1/stream_pb_service');
+
 import { StreamClient } from './client';
 
 let robotClient: RobotClient;
@@ -13,16 +17,11 @@ describe('StreamClient', () => {
   beforeEach(() => {
     vi.useFakeTimers();
 
-    vi.mock('./robot/client');
-
     robotClient = new RobotClient('fakehost');
-    vi.mock('./gen/proto/stream/v1/stream_pb_service');
-
     streamClient = new StreamClient(robotClient);
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
     vi.useRealTimers();
   });
 

--- a/src/extra/stream/client.ts
+++ b/src/extra/stream/client.ts
@@ -98,8 +98,11 @@ export class StreamClient extends EventDispatcher implements Stream {
     }
   }
 
+  private getStreamTimeout = 30_000;
+
   /**
-   * Get a stream by name from a StreamClient.
+   * Get a stream by name from a StreamClient. Will time out if stream is not
+   * received within 30 seconds.
    *
    * @param name - The name of a camera component.
    */
@@ -118,6 +121,11 @@ export class StreamClient extends EventDispatcher implements Stream {
       };
 
       this.on('track', handleTrack as (args: unknown) => void);
+
+      setTimeout(() => {
+        this.off('track', handleTrack as (args: unknown) => void);
+        reject(new Error('timed out'));
+      }, this.getStreamTimeout);
     });
 
     await this.add(name);

--- a/src/extra/stream/client.ts
+++ b/src/extra/stream/client.ts
@@ -102,7 +102,7 @@ export class StreamClient extends EventDispatcher implements Stream {
 
   /**
    * Get a stream by name from a StreamClient. Will time out if stream is not
-   * received within 30 seconds.
+   * received within 5 seconds.
    *
    * @param name - The name of a camera component.
    */

--- a/src/extra/stream/client.ts
+++ b/src/extra/stream/client.ts
@@ -98,7 +98,7 @@ export class StreamClient extends EventDispatcher implements Stream {
     }
   }
 
-  private getStreamTimeout = 30_000;
+  private STREAM_TIMEOUT = 5000;
 
   /**
    * Get a stream by name from a StreamClient. Will time out if stream is not
@@ -124,8 +124,10 @@ export class StreamClient extends EventDispatcher implements Stream {
 
       setTimeout(() => {
         this.off('track', handleTrack as (args: unknown) => void);
-        reject(new Error('timed out'));
-      }, this.getStreamTimeout);
+        reject(
+          new Error(`Did not receive a stream after ${this.STREAM_TIMEOUT} ms`)
+        );
+      }, this.STREAM_TIMEOUT);
     });
 
     await this.add(name);

--- a/src/extra/stream/client.ts
+++ b/src/extra/stream/client.ts
@@ -97,4 +97,31 @@ export class StreamClient extends EventDispatcher implements Stream {
       this.streams.delete(name);
     }
   }
+
+  /**
+   * Get a stream by name from a StreamClient.
+   *
+   * @param name - The name of a camera component.
+   */
+  getStream = async (name: string): Promise<MediaStream> => {
+    const streamPromise = new Promise<MediaStream>((resolve, reject) => {
+      const handleTrack = (event: RTCTrackEvent) => {
+        const [stream] = event.streams;
+
+        if (!stream) {
+          this.off('track', handleTrack as (args: unknown) => void);
+          reject(new Error('Recieved track event with no streams'));
+        } else if (stream.id === name) {
+          this.off('track', handleTrack as (args: unknown) => void);
+          resolve(stream);
+        }
+      };
+
+      this.on('track', handleTrack as (args: unknown) => void);
+    });
+
+    await this.add(name);
+
+    return streamPromise;
+  };
 }

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -34,7 +34,7 @@ export interface Robot {
    * Blocks on the specified operation on the robot. This function will only
    * return when the specific operation has finished or has been cancelled.
    *
-   * @param id (str) - ID of operation to block on.
+   * @param id - ID of operation to block on.
    * @group Operations
    * @alpha
    */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 import pkg from './package.json';
 
@@ -34,5 +34,8 @@ export default defineConfig({
         warn(warning);
       },
     },
+  },
+  test: {
+    mockReset: true,
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
+/// <reference types="vitest" />
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vite';
 
 import pkg from './package.json';
 


### PR DESCRIPTION
### Description 

Add a `getStream` method that adds and returns a stream from a camera. Mostly ported from the React teleop example (thanks @mcous!)

### Questions

* [x] I hardcoded a 30 second timeout to prevent this function from hanging. Is that reasonable? Should this be configurable? **
  * We settled on 5 seconds

### Testing

I ran the React teleop example using the function:

![image](https://github.com/viamrobotics/viam-typescript-sdk/assets/7954103/d37c3274-981a-4335-a296-4f9cc5c6da48)
