### PR TITLE
RSDK-4477 update move on globe wrapper

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -9,8 +9,8 @@ deps:
   - remote: buf.build
     owner: viamrobotics
     repository: api
-    commit: 10d28d2160e34f73ac5d797ce7a15522
-    digest: shake256:68ee93f460e4ddb2f0b903b7fb6d97e66452882460b3039e53e209cb7e752861437ed5757f615a927e6f37b6a8f04a5119249dfdf04a4c80b995ed1bc8e85e7c
+    commit: 567db2ef2dd04c548371f69ab31a1226
+    digest: shake256:a8bfb0b7ab720092320c8a302e89e65a4de510f8816ee18ae86673d157b70f2d3433c90dffce82ed7be2bc226781e41f3e558d9e89510a2ceccac001f7dc63cb
   - remote: buf.build
     owner: viamrobotics
     repository: goutils

--- a/src/main.ts
+++ b/src/main.ts
@@ -287,6 +287,7 @@ export {
   type LinearConstraint,
   type OrientationConstraint,
   type CollisionSpecification,
+  type MotionConfiguration,
   MotionClient,
 } from './services/motion';
 

--- a/src/services/motion.ts
+++ b/src/services/motion.ts
@@ -4,5 +4,6 @@ export type {
   LinearConstraint,
   OrientationConstraint,
   CollisionSpecification,
+  MotionConfiguration,
 } from './motion/types';
 export { MotionClient } from './motion/client';

--- a/src/services/motion/client.ts
+++ b/src/services/motion/client.ts
@@ -24,7 +24,12 @@ import type {
   Transform,
   WorldState,
 } from '../../types';
-import { type Constraints, encodeConstraints } from './types';
+import {
+  type Constraints,
+  encodeConstraints,
+  type MotionConfiguration,
+  encodeMotionConfiguration,
+} from './types';
 import type { Motion } from './motion';
 
 /**
@@ -109,13 +114,13 @@ export class MotionClient implements Motion {
     movementSensorName: ResourceName,
     heading?: number,
     obstaclesList?: GeoObstacle[],
-    linearMetersPerSec?: number,
-    angularDegPerSec?: number,
+    motionConfig?: MotionConfiguration,
     extra = {}
   ) {
     const { service } = this;
 
     const request = new pb.MoveOnGlobeRequest();
+    request.setName(this.name);
     request.setDestination(encodeGeoPoint(destination));
     request.setComponentName(encodeResourceName(componentName));
     request.setMovementSensorName(encodeResourceName(movementSensorName));
@@ -125,11 +130,8 @@ export class MotionClient implements Motion {
     if (obstaclesList) {
       request.setObstaclesList(obstaclesList.map((x) => encodeGeoObstacle(x)));
     }
-    if (linearMetersPerSec) {
-      request.setLinearMetersPerSec(linearMetersPerSec);
-    }
-    if (angularDegPerSec) {
-      request.setAngularDegPerSec(angularDegPerSec);
+    if (motionConfig) {
+      request.setMotionConfiguration(encodeMotionConfiguration(motionConfig));
     }
     request.setExtra(Struct.fromJavaScript(extra));
 

--- a/src/services/motion/motion.ts
+++ b/src/services/motion/motion.ts
@@ -9,7 +9,7 @@ import type {
   Transform,
   WorldState,
 } from '../../types';
-import type { Constraints } from './types';
+import type { Constraints, MotionConfiguration } from './types';
 
 /**
  * A service that coordinates motion planning across all of the components in a
@@ -75,8 +75,7 @@ export interface Motion extends Resource {
     movementSensorName: ResourceName,
     heading?: number,
     obstaclesList?: GeoObstacle[],
-    linearMetersPerSec?: number,
-    angularDegPerSec?: number,
+    motionConfiguration?: MotionConfiguration,
     extra?: StructType
   ) => Promise<boolean>;
 

--- a/src/services/motion/motion.ts
+++ b/src/services/motion/motion.ts
@@ -65,9 +65,8 @@ export interface Motion extends Resource {
    *   the robot's location.
    * @param obstaclesList - Obstacles to consider when planning the motion of
    *   the component.
-   * @param heading - Compass heading, in degrees, to achieve at destination
-   * @param linearMetersPerSec - Linear velocity to target when moving.
-   * @param angularDegPerSec - Angular velocity to target when moving.
+   * @param heading - Compass heading, in degrees, to achieve at destination.
+   * @param motionConfiguration - Optional motion configuration options.
    */
   moveOnGlobe: (
     destination: GeoPoint,

--- a/src/services/motion/types.ts
+++ b/src/services/motion/types.ts
@@ -1,9 +1,11 @@
 import pb from '../../gen/service/motion/v1/motion_pb';
+import { encodeResourceName } from '../../utils';
 
 export type Constraints = pb.Constraints.AsObject;
 export type LinearConstraint = pb.LinearConstraint.AsObject;
 export type OrientationConstraint = pb.OrientationConstraint.AsObject;
 export type CollisionSpecification = pb.CollisionSpecification.AsObject;
+export type MotionConfiguration = pb.MotionConfiguration.AsObject;
 
 const encodeLinearConstraint = (
   obj: pb.LinearConstraint.AsObject
@@ -54,6 +56,23 @@ export const encodeConstraints = (obj: Constraints): pb.Constraints => {
   result.setCollisionSpecificationList(
     obj.collisionSpecificationList.map((x) => encodeCollisionSpecification(x))
   );
+
+  return result;
+};
+
+export const encodeMotionConfiguration = (
+  obj: MotionConfiguration
+): pb.MotionConfiguration => {
+  const result = new pb.MotionConfiguration();
+
+  result.setVisionServicesList(
+    obj.visionServicesList.map((x) => encodeResourceName(x))
+  );
+  result.setPositionPollingFrequencyHz(obj.positionPollingFrequencyHz);
+  result.setObstaclePollingFrequencyHz(obj.obstaclePollingFrequencyHz);
+  result.setPlanDeviationM(obj.planDeviationM);
+  result.setLinearMPerSec(obj.linearMPerSec);
+  result.setAngularDegsPerSec(obj.angularDegsPerSec);
 
   return result;
 };


### PR DESCRIPTION
hotfix-ish - the source code on `main` does not build properly, even though buf api definitions _should_ be pinned to early version of the motion api. This PR updates our wrappers to use the new motion api so we can build release candidates.