### PR TITLE
RSDK-5032 - strip authentity of protocol string

### DIFF
--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -156,6 +156,7 @@ export const createRobotClient = async (
   conf: DialConf
 ): Promise<RobotClient> => {
   let client;
+  conf.authEntity = conf.authEntity?.replace(/^(?<http>.*:\/\/)/u, '');
 
   if (conf.reconnectMaxAttempts && !isPosInt(conf.reconnectMaxAttempts)) {
     throw new Error(

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -156,7 +156,9 @@ export const createRobotClient = async (
   conf: DialConf
 ): Promise<RobotClient> => {
   let client;
-  conf.authEntity = conf.authEntity?.replace(/^(?<http>.*:\/\/)/u, '');
+  if (conf.authEntity) {
+    conf.authEntity = new URL(conf.authEntity).host;
+  }
 
   if (conf.reconnectMaxAttempts && !isPosInt(conf.reconnectMaxAttempts)) {
     throw new Error(


### PR DESCRIPTION
Connection to the robot fails if the `authEntity` has a protocol string (i.e. "https://") in the beginning.

The solution was to grab the host of the `authEntity` string in ``createRobotClient`.

Tested by replacing the `main` of the vanilla example with the code sample provided from `app.viam.com` for a robot. Locally connect to a laptop as a robot through gRPC. 