### PR TITLE
Temporarily use pinned version of API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ update-buf: $(node_modules)
 .PHONY: build-buf
 build-buf: $(node_modules) clean-buf
 	$(buf) generate buf.build/googleapis/googleapis
-	$(buf) generate buf.build/viamrobotics/api --path common,component,robot,service,app
+	# TODO(NEEDS TICKET): remove hardcoded pin and create a sane way to pin protos
+	# See this thread for more details: https://viaminc.slack.com/archives/C039G724TKP/p1697119526822429
+	$(buf) generate buf.build/viamrobotics/api:2109757288234ffc8248121f60437cdd --path common,component,robot,service,app
 	$(buf) generate buf.build/erdaniels/gostream
 	$(buf) generate buf.build/viamrobotics/goutils
 

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ update-buf: $(node_modules)
 .PHONY: build-buf
 build-buf: $(node_modules) clean-buf
 	$(buf) generate buf.build/googleapis/googleapis
-	# TODO(NEEDS TICKET): remove hardcoded pin and create a sane way to pin protos
+	# TODO(RSDK-5362): remove hardcoded pin and create a sane way to pin protos
 	# See this thread for more details: https://viaminc.slack.com/archives/C039G724TKP/p1697119526822429
 	$(buf) generate buf.build/viamrobotics/api:2109757288234ffc8248121f60437cdd --path common,component,robot,service,app
 	$(buf) generate buf.build/erdaniels/gostream


### PR DESCRIPTION
Ensure that we use [this version of API protos](https://github.com/viamrobotics/api/commit/3b7699f6cb2911b25cc508733aeadd649ac62103).

This is a temporary fix until we can pin versions more generically.