### PR TITLE
RSDK-5228 - allow setting sdp values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@viamrobotics/rpc": "^0.1.37",
+        "@viamrobotics/rpc": "^0.1.38",
         "exponential-backoff": "^3.1.1"
       },
       "devDependencies": {
@@ -1385,9 +1385,9 @@
       }
     },
     "node_modules/@viamrobotics/rpc": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.1.37.tgz",
-      "integrity": "sha512-gR95RMtpkCRDmScY7gpuygPF3S+oIJdl8ELTUm5J2Nnyyk88XVZHFM6xiKdsdAFdsUe5oX6Y6TvpNh39tVxDhQ==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.1.38.tgz",
+      "integrity": "sha512-NWCXv0nKR/Ru2wor3CPy8v+0C2HRO+5epa7zw1O0zEPIRa5u6dvRQ3YNXJmE0DJhR83uLS7lWIhPqP0o/pIIPQ==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",
         "google-protobuf": "^3.14.0"
@@ -10615,9 +10615,9 @@
       "requires": {}
     },
     "@viamrobotics/rpc": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.1.37.tgz",
-      "integrity": "sha512-gR95RMtpkCRDmScY7gpuygPF3S+oIJdl8ELTUm5J2Nnyyk88XVZHFM6xiKdsdAFdsUe5oX6Y6TvpNh39tVxDhQ==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.1.38.tgz",
+      "integrity": "sha512-NWCXv0nKR/Ru2wor3CPy8v+0C2HRO+5epa7zw1O0zEPIRa5u6dvRQ3YNXJmE0DJhR83uLS7lWIhPqP0o/pIIPQ==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.13.0",
         "google-protobuf": "^3.14.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/viamrobotics/viam-typescript-sdk#readme",
   "dependencies": {
-    "@viamrobotics/rpc": "^0.1.37",
+    "@viamrobotics/rpc": "^0.1.38",
     "exponential-backoff": "^3.1.1"
   },
   "devDependencies": {

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -414,7 +414,8 @@ export class RobotClient extends EventDispatcher implements Robot {
         },
       };
 
-      if (priority && opts.webrtcOptions) {
+      // Webrtcoptions will always be defined, but TS doesn't know this
+      if ((priority === 0 || priority) && opts.webrtcOptions) {
         opts.webrtcOptions.additionalSdpFields = { 'x-priority': priority };
       }
 

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -372,7 +372,7 @@ export class RobotClient extends EventDispatcher implements Robot {
   public async connect(
     authEntity = this.savedAuthEntity,
     creds = this.savedCreds,
-    priority = 0
+    priority?: number
   ) {
     if (this.connecting) {
       // This lint is clearly wrong due to how the event loop works such that after an await, the condition may no longer be true.

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -370,9 +370,9 @@ export class RobotClient extends EventDispatcher implements Robot {
   }
 
   public async connect(
+    priority?: number,
     authEntity = this.savedAuthEntity,
-    creds = this.savedCreds,
-    priority?: number
+    creds = this.savedCreds
   ) {
     if (this.connecting) {
       // This lint is clearly wrong due to how the event loop works such that after an await, the condition may no longer be true.
@@ -405,7 +405,7 @@ export class RobotClient extends EventDispatcher implements Robot {
         webrtcOptions: {
           disableTrickleICE: false,
           rtcConfig: this.webrtcOptions?.rtcConfig,
-          priority: priority,
+          priority,
         },
       };
 

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -56,9 +56,9 @@ interface SessionOptions {
 }
 
 export interface ConnectOptions {
-  additionalSdpFields?: Record<string, string | number>;
   authEntity?: string;
   creds?: Credentials;
+  priority?: number;
 }
 
 abstract class ServiceClient {
@@ -376,9 +376,9 @@ export class RobotClient extends EventDispatcher implements Robot {
   }
 
   public async connect({
-    additionalSdpFields,
     authEntity = this.savedAuthEntity,
     creds = this.savedCreds,
+    priority,
   }: ConnectOptions = {}) {
     if (this.connecting) {
       // This lint is clearly wrong due to how the event loop works such that after an await, the condition may no longer be true.
@@ -411,9 +411,12 @@ export class RobotClient extends EventDispatcher implements Robot {
         webrtcOptions: {
           disableTrickleICE: false,
           rtcConfig: this.webrtcOptions?.rtcConfig,
-          additionalSdpFields,
         },
       };
+
+      if (priority && opts.webrtcOptions) {
+        opts.webrtcOptions.additionalSdpFields = { 'x-priority': priority };
+      }
 
       // Save authEntity, creds
       this.savedAuthEntity = authEntity;

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -371,7 +371,8 @@ export class RobotClient extends EventDispatcher implements Robot {
 
   public async connect(
     authEntity = this.savedAuthEntity,
-    creds = this.savedCreds
+    creds = this.savedCreds,
+    priority = 0
   ) {
     if (this.connecting) {
       // This lint is clearly wrong due to how the event loop works such that after an await, the condition may no longer be true.
@@ -404,6 +405,7 @@ export class RobotClient extends EventDispatcher implements Robot {
         webrtcOptions: {
           disableTrickleICE: false,
           rtcConfig: this.webrtcOptions?.rtcConfig,
+          priority: priority,
         },
       };
 

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -415,7 +415,7 @@ export class RobotClient extends EventDispatcher implements Robot {
       };
 
       // Webrtcoptions will always be defined, but TS doesn't know this
-      if ((priority === 0 || priority) && opts.webrtcOptions) {
+      if (priority !== undefined && opts.webrtcOptions) {
         opts.webrtcOptions.additionalSdpFields = { 'x-priority': priority };
       }
 

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -56,7 +56,7 @@ interface SessionOptions {
 }
 
 export interface ConnectOptions {
-  additionalSdpFields?: object;
+  additionalSdpFields?: Record<string, string | number>;
   authEntity?: string;
   creds?: Credentials;
 }

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -56,7 +56,7 @@ interface SessionOptions {
 }
 
 export interface ConnectOptions {
-  priority?: number;
+  additionalSdpFields?: object;
   authEntity?: string;
   creds?: Credentials;
 }
@@ -376,7 +376,7 @@ export class RobotClient extends EventDispatcher implements Robot {
   }
 
   public async connect({
-    priority,
+    additionalSdpFields,
     authEntity = this.savedAuthEntity,
     creds = this.savedCreds,
   }: ConnectOptions) {
@@ -411,7 +411,7 @@ export class RobotClient extends EventDispatcher implements Robot {
         webrtcOptions: {
           disableTrickleICE: false,
           rtcConfig: this.webrtcOptions?.rtcConfig,
-          priority,
+          additionalSdpFields,
         },
       };
 

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -55,6 +55,12 @@ interface SessionOptions {
   disabled: boolean;
 }
 
+export interface ConnectOptions {
+  priority?: number;
+  authEntity?: string;
+  creds?: Credentials;
+}
+
 abstract class ServiceClient {
   constructor(public serviceHost: string, public options?: grpc.RpcOptions) {}
 }
@@ -164,7 +170,7 @@ export class RobotClient extends EventDispatcher implements Robot {
       console.debug('connection closed, will try to reconnect');
       void backOff(
         () =>
-          this.connect().then(
+          this.connect({}).then(
             () => {
               // eslint-disable-next-line no-console
               console.debug('reconnected successfully!');
@@ -369,11 +375,11 @@ export class RobotClient extends EventDispatcher implements Robot {
     return this.peerConn?.iceConnectionState === 'connected';
   }
 
-  public async connect(
-    priority?: number,
+  public async connect({
+    priority,
     authEntity = this.savedAuthEntity,
-    creds = this.savedCreds
-  ) {
+    creds = this.savedCreds,
+  }: ConnectOptions) {
     if (this.connecting) {
       // This lint is clearly wrong due to how the event loop works such that after an await, the condition may no longer be true.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -170,7 +170,7 @@ export class RobotClient extends EventDispatcher implements Robot {
       console.debug('connection closed, will try to reconnect');
       void backOff(
         () =>
-          this.connect({}).then(
+          this.connect().then(
             () => {
               // eslint-disable-next-line no-console
               console.debug('reconnected successfully!');
@@ -379,7 +379,7 @@ export class RobotClient extends EventDispatcher implements Robot {
     additionalSdpFields,
     authEntity = this.savedAuthEntity,
     creds = this.savedCreds,
-  }: ConnectOptions) {
+  }: ConnectOptions = {}) {
     if (this.connecting) {
       // This lint is clearly wrong due to how the event loop works such that after an await, the condition may no longer be true.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -90,7 +90,7 @@ export interface DialWebRTCConf {
   // WebRTC
   signalingAddress: string;
   iceServers?: ICEServer[];
-  priority?: number;
+  additionalSdpFields?: object;
 }
 
 const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
@@ -122,7 +122,7 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
     creds = conf.credential;
   }
   await client.connect({
-    priority: conf.priority,
+    additionalSdpFields: conf.additionalSdpFields,
     authEntity: conf.authEntity || impliedURL,
     creds: creds,
   });

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -90,7 +90,7 @@ export interface DialWebRTCConf {
   // WebRTC
   signalingAddress: string;
   iceServers?: ICEServer[];
-  additionalSdpFields?: object;
+  additionalSdpFields?: Record<string, string | number>;
 }
 
 const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -58,7 +58,7 @@ const dialDirect = async (conf: DialDirectConf): Promise<RobotClient> => {
   if (conf.credential) {
     creds = conf.credential;
   }
-  await client.connect(undefined, conf.authEntity, creds);
+  await client.connect({ authEntity: conf.authEntity, creds: creds });
 
   // eslint-disable-next-line no-console
   console.debug('connected via gRPC');
@@ -121,7 +121,11 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
   if (conf.credential) {
     creds = conf.credential;
   }
-  await client.connect(conf.priority, conf.authEntity || impliedURL, creds);
+  await client.connect({
+    priority: conf.priority,
+    authEntity: conf.authEntity || impliedURL,
+    creds: creds,
+  });
 
   // eslint-disable-next-line no-console
   console.debug('connected via WebRTC');

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -122,9 +122,9 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
     creds = conf.credential;
   }
   await client.connect({
-    priority: conf.priority,
     authEntity: conf.authEntity || impliedURL,
     creds,
+    priority: conf.priority,
   });
 
   // eslint-disable-next-line no-console

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -90,6 +90,7 @@ export interface DialWebRTCConf {
   // WebRTC
   signalingAddress: string;
   iceServers?: ICEServer[];
+  priority?: number;
 }
 
 const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
@@ -120,7 +121,7 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
   if (conf.credential) {
     creds = conf.credential;
   }
-  await client.connect(conf.authEntity || impliedURL, creds);
+  await client.connect(conf.authEntity || impliedURL, creds, conf.priority);
 
   // eslint-disable-next-line no-console
   console.debug('connected via WebRTC');

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -58,7 +58,7 @@ const dialDirect = async (conf: DialDirectConf): Promise<RobotClient> => {
   if (conf.credential) {
     creds = conf.credential;
   }
-  await client.connect({ authEntity: conf.authEntity, creds: creds });
+  await client.connect({ authEntity: conf.authEntity, creds });
 
   // eslint-disable-next-line no-console
   console.debug('connected via gRPC');
@@ -90,7 +90,7 @@ export interface DialWebRTCConf {
   // WebRTC
   signalingAddress: string;
   iceServers?: ICEServer[];
-  additionalSdpFields?: Record<string, string | number>;
+  priority?: number;
 }
 
 const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
@@ -122,9 +122,9 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
     creds = conf.credential;
   }
   await client.connect({
-    additionalSdpFields: conf.additionalSdpFields,
+    priority: conf.priority,
     authEntity: conf.authEntity || impliedURL,
-    creds: creds,
+    creds,
   });
 
   // eslint-disable-next-line no-console

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -58,7 +58,7 @@ const dialDirect = async (conf: DialDirectConf): Promise<RobotClient> => {
   if (conf.credential) {
     creds = conf.credential;
   }
-  await client.connect(conf.authEntity, creds);
+  await client.connect(undefined, conf.authEntity, creds);
 
   // eslint-disable-next-line no-console
   console.debug('connected via gRPC');
@@ -121,7 +121,7 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
   if (conf.credential) {
     creds = conf.credential;
   }
-  await client.connect(conf.authEntity || impliedURL, creds, conf.priority);
+  await client.connect(conf.priority, conf.authEntity || impliedURL, creds);
 
   // eslint-disable-next-line no-console
   console.debug('connected via WebRTC');


### PR DESCRIPTION
[Related goutils change](https://github.com/viamrobotics/goutils/pull/215)
[Jira ticket](https://viam.atlassian.net/browse/RSDK-5228)

Allowing for a custom priority attribute to be pushed in.

Tested with a board running the MicroRDK to confirm default and customized priority works as expected. Also tested with a robot running the regular RDK (with and without a priority attribute) to confirm everything else still works.

NOTE: The `build_lint_test` error seems to be caused by goutils, and should be solved with the goutils change linked above.

How could we test this, or is it okay not to add tests for this?