### PR TITLE
RSDK-5477 - clearer tabular data objects

### DIFF
--- a/src/app/data-client.test.ts
+++ b/src/app/data-client.test.ts
@@ -60,8 +60,8 @@ describe('DataClient tests', () => {
       const promise = await subject().tabularDataByFilter();
       expect(promise.length).toEqual(2);
       const [data1, data2] = promise;
-      expect(data1).toMatchObject(tabData1.getData().toJavaScript());
-      expect(data2).toMatchObject(tabData2.getData().toJavaScript());
+      expect(data1).toMatchObject({ key: 'value1' });
+      expect(data2).toMatchObject({ key: 'value2' });
     });
 
     test('get filtered tabular data', async () => {

--- a/src/app/data-client.test.ts
+++ b/src/app/data-client.test.ts
@@ -60,8 +60,8 @@ describe('DataClient tests', () => {
       const promise = await subject().tabularDataByFilter();
       expect(promise.length).toEqual(2);
       const [data1, data2] = promise;
-      expect(data1).toMatchObject(tabData1.toObject().data);
-      expect(data2).toMatchObject(tabData2.toObject().data);
+      expect(data1).toMatchObject(tabData1.getData().toJavaScript());
+      expect(data2).toMatchObject(tabData2.getData().toJavaScript());
     });
 
     test('get filtered tabular data', async () => {

--- a/src/app/data-client.test.ts
+++ b/src/app/data-client.test.ts
@@ -60,8 +60,8 @@ describe('DataClient tests', () => {
       const promise = await subject().tabularDataByFilter();
       expect(promise.length).toEqual(2);
       const [data1, data2] = promise;
-      expect(data1).toMatchObject(tabData1.toObject());
-      expect(data2).toMatchObject(tabData2.toObject());
+      expect(data1).toMatchObject(tabData1.toObject().data);
+      expect(data2).toMatchObject(tabData2.toObject().data);
     });
 
     test('get filtered tabular data', async () => {

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -30,7 +30,7 @@ export class DataClient {
   /**
    * Filter and download tabular data. The returned metadata might be empty if
    * the metadata index of the data is out of the bounds of the returned
-   * metadata list
+   * metadata list.
    *
    * @param filter - Optional `pb.Filter` specifying tabular data to retrieve.
    *   No `filter` implies all tabular data.

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -54,16 +54,16 @@ export class DataClient {
       }
       dataArray.push(
         ...dataList.map((data) => {
-          const index = data.getMetadataIndex();
+          const mdIndex = data.getMetadataIndex();
           const mdListLength = response.getMetadataList().length;
-          if (mdListLength != 0 && index >= mdListLength) {
+          if (mdListLength != 0 && mdIndex >= mdListLength) {
             throw Error(
-              `metadata index ${index} is out of response's metadata list`
+              `metadata index ${mdIndex} is out of response's metadata list`
             );
           }
           return {
             ...data.getData()?.toJavaScript(),
-            metadata: response.getMetadataList()[index]?.toObject(),
+            metadata: response.getMetadataList()[mdIndex]?.toObject(),
             timeRequested: data.getTimeRequested()?.toDate(),
             timeReceived: data.getTimeReceived()?.toDate(),
           };

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -14,7 +14,7 @@ export type FilterOptions = Partial<pb.Filter.AsObject> & {
 };
 
 type TabularData = {
-  data?: googleStructPb.JavaScriptValue;
+  data?: { [key: string]: googleStructPb.JavaScriptValue };
   metadata?: pb.CaptureMetadata.AsObject;
   timeRequested?: Date;
   timeReceived?: Date;
@@ -28,6 +28,10 @@ export class DataClient {
   }
 
   async tabularDataByFilter(filter?: pb.Filter) {
+    /*
+     * The returned metadata might be empty if the metadata index of
+     * the data is out of the bounds of the returned metadata list
+     */
     const { service } = this;
 
     let last = '';
@@ -57,10 +61,6 @@ export class DataClient {
       dataArray.push(
         ...dataList.map((data) => {
           const mdIndex = data.getMetadataIndex();
-          /*
-           * The returned metadata might be empty if the metadata index of
-           * the data is out of the bounds of the returned metadata list
-           */
           const metadata =
             mdListLength !== 0 && mdIndex >= mdListLength
               ? new pb.CaptureMetadata().toObject()

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -15,7 +15,7 @@ export type FilterOptions = Partial<pb.Filter.AsObject> & {
 
 type TabularData = {
   data?: googleStructPb.Struct.AsObject;
-  metadataIndex: number;
+  metadata?: pb.CaptureMetadata.AsObject;
   timeRequested?: Date;
   timeReceived?: Date;
 };
@@ -54,7 +54,10 @@ export class DataClient {
       }
       dataArray.push(
         ...dataList.map((data) => ({
-          ...data.toObject(),
+          ...data.toObject().data,
+          metadata: response
+            .getMetadataList()
+            [data.getMetadataIndex()]?.toObject(),
           timeRequested: data.getTimeRequested()?.toDate(),
           timeReceived: data.getTimeReceived()?.toDate(),
         }))

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -53,14 +53,20 @@ export class DataClient {
         break;
       }
       dataArray.push(
-        ...dataList.map((data) => ({
-          ...data.getData().toJavaScript(),
-          metadata: response
-            .getMetadataList()
-            [data.getMetadataIndex()]?.toObject(),
-          timeRequested: data.getTimeRequested()?.toDate(),
-          timeReceived: data.getTimeReceived()?.toDate(),
-        }))
+        ...dataList.map((data) => {
+          const index = data.getMetadataIndex();
+          if (index > response.getMetadataList().length) {
+            throw Error(
+              `metadata index ${index} is out of response's metadata list`
+            );
+          }
+          return {
+            ...data.getData()?.toJavaScript(),
+            metadata: response.getMetadataList()[index]?.toObject(),
+            timeRequested: data.getTimeRequested()?.toDate(),
+            timeReceived: data.getTimeReceived()?.toDate(),
+          };
+        })
       );
       last = response.getLast();
     }

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -26,12 +26,12 @@ export class DataClient {
   constructor(serviceHost: string, grpcOptions: RpcOptions) {
     this.service = new DataServiceClient(serviceHost, grpcOptions);
   }
-
+    /**
+     * Filter and download tabular data. The returned metadata might be empty if the
+     * metadata index of the data is out of the bounds of the returned metadata list
+     * @param filter - Optional `pb.Filter` specifying tabular data to retrieve. No `filter` implies all tabular data.
+     **/
   async tabularDataByFilter(filter?: pb.Filter) {
-    /*
-     * The returned metadata might be empty if the metadata index of
-     * the data is out of the bounds of the returned metadata list
-     */
     const { service } = this;
 
     let last = '';

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -55,7 +55,8 @@ export class DataClient {
       dataArray.push(
         ...dataList.map((data) => {
           const index = data.getMetadataIndex();
-          if (index > response.getMetadataList().length) {
+          const mdListLength = response.getMetadataList().length;
+          if (mdListLength != 0 && index >= mdListLength) {
             throw Error(
               `metadata index ${index} is out of response's metadata list`
             );

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -26,11 +26,15 @@ export class DataClient {
   constructor(serviceHost: string, grpcOptions: RpcOptions) {
     this.service = new DataServiceClient(serviceHost, grpcOptions);
   }
-    /**
-     * Filter and download tabular data. The returned metadata might be empty if the
-     * metadata index of the data is out of the bounds of the returned metadata list
-     * @param filter - Optional `pb.Filter` specifying tabular data to retrieve. No `filter` implies all tabular data.
-     **/
+
+  /**
+   * Filter and download tabular data. The returned metadata might be empty if
+   * the metadata index of the data is out of the bounds of the returned
+   * metadata list
+   *
+   * @param filter - Optional `pb.Filter` specifying tabular data to retrieve.
+   *   No `filter` implies all tabular data.
+   */
   async tabularDataByFilter(filter?: pb.Filter) {
     const { service } = this;
 

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -54,7 +54,7 @@ export class DataClient {
       }
       dataArray.push(
         ...dataList.map((data) => ({
-          ...data.toObject().data,
+          ...data.getData().toJavaScript(),
           metadata: response
             .getMetadataList()
             [data.getMetadataIndex()]?.toObject(),

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -56,8 +56,8 @@ export class DataClient {
         ...dataList.map((data) => {
           const mdIndex = data.getMetadataIndex();
           const mdListLength = response.getMetadataList().length;
-          if (mdListLength != 0 && mdIndex >= mdListLength) {
-            throw Error(
+          if (mdListLength !== 0 && mdIndex >= mdListLength) {
+            throw new Error(
               `metadata index ${mdIndex} is out of response's metadata list`
             );
           }


### PR DESCRIPTION
Originally, the data object just came with a metadata index and printed out unclear data. Now the data object includes the metadata for each data object. We now also call `toJavaScript()` to display the data, which makes things clearer.
The data now looks like this:
```  
  {
    "Lat": demo,
    "Lng": demo,
    "metadata": {
      "organizationId": "demo",
      "locationId": "demo",
      "robotName": "demo",
      "robotId": "demo",
      "partName": "demo",
      "partId": "demo",
      "componentType": "demo",
      "componentName": "demo",
      "methodName": "demo",
      "methodParametersMap": [],
      "tagsList": [],
      "mimeType": "demo"
    },
    "timeRequested": "2023-10-27T19:06:00.497Z",
    "timeReceived": "2023-10-27T19:06:00.497Z"
  },
```