### PR TITLE
Add default check connection interval to be 10 seconds

### DIFF
--- a/src/robot/grpc-connection-manager.ts
+++ b/src/robot/grpc-connection-manager.ts
@@ -16,17 +16,18 @@ const timeoutBlob = new Blob(
 export default class GRPCConnectionManager {
   private innerTransportFactory: grpc.TransportFactory;
   private client: RobotServiceClient;
-  private heartbeatIntervalMs: number | undefined;
+  private heartbeatIntervalMs: number;
 
   public connecting: Promise<void> | undefined;
   private connectResolve: (() => void) | undefined;
   private connectReject: ((reason: ServiceError) => void) | undefined;
 
-  constructor(serviceHost: string, transportFactory: grpc.TransportFactory) {
+  constructor(serviceHost: string, transportFactory: grpc.TransportFactory, heartbeatIntervalMs = 10_000) {
     this.innerTransportFactory = transportFactory;
     this.client = new RobotServiceClient(serviceHost, {
       transport: this.innerTransportFactory,
     });
+    this.heartbeatIntervalMs = heartbeatIntervalMs;
   }
 
   public heartbeat() {

--- a/src/robot/grpc-connection-manager.ts
+++ b/src/robot/grpc-connection-manager.ts
@@ -22,7 +22,11 @@ export default class GRPCConnectionManager {
   private connectResolve: (() => void) | undefined;
   private connectReject: ((reason: ServiceError) => void) | undefined;
 
-  constructor(serviceHost: string, transportFactory: grpc.TransportFactory, heartbeatIntervalMs = 10_000) {
+  constructor(
+    serviceHost: string,
+    transportFactory: grpc.TransportFactory,
+    heartbeatIntervalMs = 10_000
+  ) {
     this.innerTransportFactory = transportFactory;
     this.client = new RobotServiceClient(serviceHost, {
       transport: this.innerTransportFactory,


### PR DESCRIPTION
The SDK didn't actually set the `heartbeatIntervalMs` for the gRPC check connection interval. This creates a default value of 10 seconds.