### PR TITLE
RSDK-5735 Create app client with access token

### DIFF
--- a/examples/connect-app/package-lock.json
+++ b/examples/connect-app/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../..": {
       "name": "@viamrobotics/sdk",
-      "version": "0.6.0",
+      "version": "0.7.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.38",

--- a/examples/connect-app/src/main.ts
+++ b/examples/connect-app/src/main.ts
@@ -1,19 +1,18 @@
-import { type DialOptions } from '@viamrobotics/rpc/src/dial';
 import * as VIAM from '@viamrobotics/sdk';
 
+const API_KEY_ID = import.meta.env.VITE_API_KEY_ID;
+const API_KEY_SECRET = import.meta.env.VITE_API_KEY_SECRET;
+
 async function connect(): Promise<VIAM.ViamClient> {
-  const credential = {
-    payload: '<API-KEY>',
-    type: 'api-key',
+  const opts: VIAM.ViamClientOptions = {
+    credential: {
+      type: 'api-key',
+      authEntity: API_KEY_ID,
+      payload: API_KEY_SECRET,
+    },
   };
 
-  const dialOpts: DialOptions = {
-    authEntity: '<API-KEY-ID>',
-    credentials: credential,
-  };
-
-  const client = new VIAM.ViamClient(dialOpts);
-  await client.connect();
+  const client = await VIAM.createViamClient(opts);
 
   return client;
 }
@@ -22,6 +21,7 @@ const button = <HTMLButtonElement>document.getElementById('main-button');
 
 async function run(client: VIAM.ViamClient) {
   // A filter is an optional tool to filter out which data comes back.
+  // const opts: VIAM.FilterOptions = { componentType: 'camera' };
   const opts: VIAM.FilterOptions = { componentType: 'camera' };
   const filter = client.dataClient.createFilter(opts);
 

--- a/examples/connect-app/src/vite-env.d.ts
+++ b/examples/connect-app/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/src/app/viam-client.test.ts
+++ b/src/app/viam-client.test.ts
@@ -1,17 +1,16 @@
 import { FakeTransportBuilder } from '@improbable-eng/grpc-web-fake-transport';
 import { type DialOptions } from '@viamrobotics/rpc/src/dial';
 import { describe, expect, test, vi } from 'vitest';
-import { createViamTransportFactory } from '../robot/dial';
-import { DataClient } from './data-client';
-import { ViamClient } from './viam-client';
-
-vi.mock('../robot/dial', () => {
+import { createViamTransportFactory } from './viam-transport';
+vi.mock('./viam-transport', () => {
   return {
     createViamTransportFactory: vi
       .fn()
       .mockReturnValue(() => new FakeTransportBuilder().build()),
   };
 });
+import { DataClient } from './data-client';
+import { ViamClient } from './viam-client';
 
 describe('ViamClient', () => {
   let dialOpts: DialOptions = {};

--- a/src/app/viam-client.ts
+++ b/src/app/viam-client.ts
@@ -1,6 +1,6 @@
 import { grpc } from '@improbable-eng/grpc-web';
 import { type DialOptions } from '@viamrobotics/rpc/src/dial';
-import { createViamTransportFactory } from '../robot/dial';
+import { createViamTransportFactory } from './viam-transport';
 import { DataClient } from './data-client';
 
 export class ViamClient {

--- a/src/app/viam-client.ts
+++ b/src/app/viam-client.ts
@@ -7,11 +7,16 @@ import {
 import { DataClient } from './data-client';
 
 export interface ViamClientOptions {
+  /** URI of the Viam app. Defaults to 'https://app.viam.com' */
   serviceHost?: string;
+  /**
+   * Either an access token that can access protected resources directly or a
+   * credential that can be exchanged for an access token.
+   */
   credential: Credential | AccessToken;
 }
 
-/** Instantiate a connected Viam client */
+/** Instantiate a connected gRPC client that interfaces with Viam app. */
 export const createViamClient = async (
   options: ViamClientOptions
 ): Promise<ViamClient> => {
@@ -26,6 +31,7 @@ export const createViamClient = async (
   return client;
 };
 
+/** A gRPC client for method calls to Viam app. */
 export class ViamClient {
   private transportFactory: grpc.TransportFactory;
   private serviceHost: string;

--- a/src/app/viam-client.ts
+++ b/src/app/viam-client.ts
@@ -7,24 +7,18 @@ import {
 import { DataClient } from './data-client';
 
 export interface ViamClientOptions {
-  /** URI of the Viam app. Defaults to 'https://app.viam.com' */
   serviceHost?: string;
-  /**
-   * Either an access token that can access protected resources directly or a
-   * credential that can be exchanged for an access token.
-   */
   credential: Credential | AccessToken;
 }
 
 /** Instantiate a connected gRPC client that interfaces with Viam app. */
-export const createViamClient = async (
-  options: ViamClientOptions
-): Promise<ViamClient> => {
-  const serviceHost = options.serviceHost ?? 'https://app.viam.com';
-
+export const createViamClient = async ({
+  serviceHost = 'https://app.viam.com',
+  credential,
+}: ViamClientOptions): Promise<ViamClient> => {
   const transportFactory = await createViamTransportFactory(
     serviceHost,
-    options.credential
+    credential
   );
   const client = new ViamClient(transportFactory, serviceHost);
   client.connect();

--- a/src/app/viam-client.ts
+++ b/src/app/viam-client.ts
@@ -3,6 +3,36 @@ import { type DialOptions } from '@viamrobotics/rpc/src/dial';
 import { createViamTransportFactory } from './viam-transport';
 import { DataClient } from './data-client';
 
+export interface ViamClientOptions {
+  serviceHost: string;
+  authEntity?: string;
+  credential?: Credential;
+}
+
+export interface Credential {
+  type: CredentialType;
+  payload: string;
+}
+
+export type CredentialType =
+  | 'robot-location-secret'
+  | 'robot-secret'
+  | 'api-key'
+  | 'access-token';
+
+/** Instantiate a connected Viam client */
+export const createViamClient = async (
+  options: ViamClientOptions
+): Promise<ViamClient> => {
+  const client = new ViamClient(
+    { authEntity: options.authEntity, credentials: options.credential },
+    options.serviceHost
+  );
+  await client.connect();
+  return client;
+};
+
+// TODO: deprecate and expose constructor
 export class ViamClient {
   private serviceHost: string;
   private dialOpts: DialOptions;

--- a/src/app/viam-transport.ts
+++ b/src/app/viam-transport.ts
@@ -1,4 +1,75 @@
 import { grpc } from '@improbable-eng/grpc-web';
+import { dialDirect, type DialOptions } from '@viamrobotics/rpc/src/dial';
+
+import { AuthenticateRequest, Credentials } from '../gen/proto/rpc/v1/auth_pb';
+import { AuthServiceClient } from '../gen/proto/rpc/v1/auth_pb_service';
+
+/**
+ * Get a Viam Transport Factory after getting the accessToken.
+ *
+ * In dialOpts.credentials, the credential type cannot be a robot secret. The
+ * credential type to use would preferably be the organization api key.
+ */
+export const createViamTransportFactory = async (
+  serviceHost: string,
+  dialOpts: DialOptions
+): Promise<grpc.TransportFactory> => {
+  const transportFactory = await dialDirect(serviceHost);
+
+  // if a token is provided, create a transport factory that uses it
+  let accessToken: string;
+  if (dialOpts.credentials && dialOpts.credentials.type === 'access-token') {
+    accessToken = dialOpts.credentials.payload;
+    console.debug('Using provided token', accessToken);
+    return (opts: grpc.TransportOptions): ViamTransport => {
+      return new ViamTransport(transportFactory, opts, accessToken);
+    };
+  }
+
+  console.debug('need to fetch access token');
+
+  /**
+   * If a token is not provided, we need to obtain one with either a
+   * 'robot-location-secret' or an 'api-key'
+   */
+  const authClient = new AuthServiceClient(serviceHost, {
+    transport: transportFactory,
+  });
+  if (!dialOpts.credentials) {
+    throw new Error(`credential cannot be none`);
+  } else if (dialOpts.credentials.type === 'robot-secret') {
+    throw new Error(
+      `credential type cannot be 'robot-secret'. Must be either 'robot-location-secret' or 'api-key'.`
+    );
+  } else if (!dialOpts.authEntity) {
+    throw new Error(
+      `auth entity cannot be null, undefined, or an empty value.`
+    );
+  }
+
+  const entity = dialOpts.authEntity;
+  const creds = new Credentials();
+  creds.setType(dialOpts.credentials.type);
+  creds.setPayload(dialOpts.credentials.payload);
+
+  const req = new AuthenticateRequest();
+  req.setEntity(entity);
+  req.setCredentials(creds);
+
+  accessToken = await new Promise<string>((resolve, reject) => {
+    authClient.authenticate(req, new grpc.Metadata(), (err, response) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(response?.getAccessToken().toString() ?? '');
+    });
+  });
+
+  console.debug('Using fetched token', accessToken);
+  return (opts: grpc.TransportOptions): ViamTransport => {
+    return new ViamTransport(transportFactory, opts, accessToken);
+  };
+};
 
 export class ViamTransport implements grpc.Transport {
   private accessToken: string;

--- a/src/app/viam-transport.ts
+++ b/src/app/viam-transport.ts
@@ -4,6 +4,7 @@ import { dialDirect } from '@viamrobotics/rpc/src/dial';
 import { AuthenticateRequest, Credentials } from '../gen/proto/rpc/v1/auth_pb';
 import { AuthServiceClient } from '../gen/proto/rpc/v1/auth_pb_service';
 
+/** A credential that can be exchanged to obtain an access token */
 export interface Credential {
   authEntity: string;
   type: CredentialType;
@@ -15,16 +16,15 @@ export type CredentialType =
   | 'api-key'
   | 'robot-secret';
 
+/** An access token used to access protected resources. */
 export interface AccessToken {
   type: 'access-token';
   payload: string;
 }
 
 /**
- * Get a Viam Transport Factory after getting the accessToken.
- *
- * In dialOpts.credentials, the credential type cannot be a robot secret. The
- * credential type to use would preferably be the organization api key.
+ * Initialize an authenticated transport factory that can access protected
+ * resources.
  */
 export const createViamTransportFactory = async (
   serviceHost: string,
@@ -52,10 +52,6 @@ const createWithCredential = async (
 ): Promise<grpc.TransportFactory> => {
   const transportFactory = await dialDirect(serviceHost);
 
-  /**
-   * If a token is not provided, we need to obtain one with either a
-   * 'robot-location-secret' or an 'api-key'
-   */
   const authClient = new AuthServiceClient(serviceHost, {
     transport: transportFactory,
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,13 @@ export {
  */
 export { RobotClient as Client } from './robot';
 
-export { ViamClient } from './app/viam-client';
+export {
+  ViamClient,
+  createViamClient,
+  type ViamClientOptions,
+  type Credential,
+  type CredentialType,
+} from './app/viam-client';
 
 /**
  * Raw Protobuf interfaces for a Data service.

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,12 +27,16 @@ export {
 export { RobotClient as Client } from './robot';
 
 export {
-  ViamClient,
   createViamClient,
+  type ViamClient,
   type ViamClientOptions,
-  type Credential,
-  type CredentialType,
 } from './app/viam-client';
+
+export type {
+  Credential,
+  CredentialType,
+  AccessToken,
+} from './app/viam-transport';
 
 /**
  * Raw Protobuf interfaces for a Data service.

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -1,11 +1,3 @@
-import {
-  dialDirect as nodeDialDirect,
-  type DialOptions,
-} from '@viamrobotics/rpc/src/dial';
-import { grpc } from '@improbable-eng/grpc-web';
-import { ViamTransport } from '../app/viam-transport';
-import { AuthenticateRequest, Credentials } from '../gen/proto/rpc/v1/auth_pb';
-import { AuthServiceClient } from '../gen/proto/rpc/v1/auth_pb_service';
 import { RobotClient } from './client';
 
 interface Credential {
@@ -206,71 +198,4 @@ export const createRobotClient = async (
   }
 
   return client;
-};
-
-/**
- * Get a Viam Transport Factory after getting the accessToken.
- *
- * In dialOpts.credentials, the credential type cannot be a robot secret. The
- * credential type to use would preferably be the organization api key.
- */
-export const createViamTransportFactory = async (
-  serviceHost: string,
-  dialOpts: DialOptions
-): Promise<grpc.TransportFactory> => {
-  const transportFactory = await nodeDialDirect(serviceHost);
-
-  // if a token is provided, create a transport factory that uses it
-  let accessToken: string;
-  if (dialOpts.credentials && dialOpts.credentials.type === 'access-token') {
-    accessToken = dialOpts.credentials.payload;
-    console.debug('Using provided token', accessToken);
-    return (opts: grpc.TransportOptions): ViamTransport => {
-      return new ViamTransport(transportFactory, opts, accessToken);
-    };
-  }
-
-  console.debug('need to fetch access token');
-
-  /**
-   * If a token is not provided, we need to obtain one with either a
-   * 'robot-location-secret' or an 'api-key'
-   */
-  const authClient = new AuthServiceClient(serviceHost, {
-    transport: transportFactory,
-  });
-  if (!dialOpts.credentials) {
-    throw new Error(`credential cannot be none`);
-  } else if (dialOpts.credentials.type === 'robot-secret') {
-    throw new Error(
-      `credential type cannot be 'robot-secret'. Must be either 'robot-location-secret' or 'api-key'.`
-    );
-  } else if (!dialOpts.authEntity) {
-    throw new Error(
-      `auth entity cannot be null, undefined, or an empty value.`
-    );
-  }
-
-  const entity = dialOpts.authEntity;
-  const creds = new Credentials();
-  creds.setType(dialOpts.credentials.type);
-  creds.setPayload(dialOpts.credentials.payload);
-
-  const req = new AuthenticateRequest();
-  req.setEntity(entity);
-  req.setCredentials(creds);
-
-  accessToken = await new Promise<string>((resolve, reject) => {
-    authClient.authenticate(req, new grpc.Metadata(), (err, response) => {
-      if (err) {
-        return reject(err);
-      }
-      return resolve(response?.getAccessToken().toString() ?? '');
-    });
-  });
-
-  console.debug('Using fetched token', accessToken);
-  return (opts: grpc.TransportOptions): ViamTransport => {
-    return new ViamTransport(transportFactory, opts, accessToken);
-  };
 };


### PR DESCRIPTION
Changes:

* App client accepts access tokens that are obtained from an outside flows (like oauth for example).

Flyby:

* Require the app clients to be created with the `createViamClient` - this breaks the current interface, but will allow us to make similar interfaces in a non-breaking way in the future.