### PR TITLE
RSDK-4825: Add getPaths to navigation service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1-next.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/sdk",
-      "version": "0.8.0",
+      "version": "0.8.1-next.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@viamrobotics/rpc": "^0.1.39",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/sdk",
-  "version": "0.8.0",
+  "version": "0.8.1-next.0",
   "description": "",
   "main": "./dist/main.umd.js",
   "module": "./dist/main.es.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -337,6 +337,7 @@ export {
   type ModeMap,
   type Waypoint,
   type NavigationPosition,
+  type Path,
   NavigationClient,
 } from './services/navigation';
 

--- a/src/services/navigation.ts
+++ b/src/services/navigation.ts
@@ -1,3 +1,8 @@
 export type { Navigation } from './navigation/navigation';
-export type { ModeMap, Waypoint, NavigationPosition } from './navigation/types';
+export type {
+  ModeMap,
+  Waypoint,
+  NavigationPosition,
+  Path,
+} from './navigation/types';
 export { NavigationClient } from './navigation/client';

--- a/src/services/navigation/client.ts
+++ b/src/services/navigation/client.ts
@@ -151,6 +151,23 @@ export class NavigationClient implements Navigation {
     return response.getObstaclesList().map((x) => x.toObject());
   }
 
+  async getPaths(extra = {}) {
+    const { service } = this;
+
+    const request = new pb.GetPathsRequest();
+    request.setName(this.name);
+    request.setExtra(Struct.fromJavaScript(extra));
+
+    this.options.requestLogger?.(request);
+
+    const response = await promisify<
+      pb.GetPathsRequest,
+      pb.GetPathsResponse
+    >(service.getPaths.bind(service), request);
+
+    return response.getPathsList().map((x) => x.toObject());
+  }
+
   async doCommand(command: StructType): Promise<StructType> {
     const { service } = this;
     return doCommandFromClient(service, this.name, command, this.options);

--- a/src/services/navigation/client.ts
+++ b/src/services/navigation/client.ts
@@ -160,10 +160,10 @@ export class NavigationClient implements Navigation {
 
     this.options.requestLogger?.(request);
 
-    const response = await promisify<
-      pb.GetPathsRequest,
-      pb.GetPathsResponse
-    >(service.getPaths.bind(service), request);
+    const response = await promisify<pb.GetPathsRequest, pb.GetPathsResponse>(
+      service.getPaths.bind(service),
+      request
+    );
 
     return response.getPathsList().map((x) => x.toObject());
   }

--- a/src/services/navigation/navigation.ts
+++ b/src/services/navigation/navigation.ts
@@ -1,5 +1,5 @@
 import type { GeoObstacle, GeoPoint, Resource, StructType } from '../../types';
-import type { ModeMap, Waypoint, NavigationPosition } from './types';
+import type { ModeMap, Waypoint, NavigationPosition, Path } from './types';
 
 /**
  * A service that uses GPS to automatically navigate a robot to user defined
@@ -40,4 +40,7 @@ export interface Navigation extends Resource {
 
   /** Get a list of obstacles. */
   getObstacles: (extra?: StructType) => Promise<GeoObstacle[]>;
+
+  /** Gets the list of paths known to the navigation service. */
+  getPaths: (extra?: StructType) => Promise<Path[]>;
 }

--- a/src/services/navigation/types.ts
+++ b/src/services/navigation/types.ts
@@ -3,3 +3,4 @@ import pb from '../../gen/service/navigation/v1/navigation_pb';
 export type ModeMap = pb.ModeMap;
 export type Waypoint = pb.Waypoint.AsObject;
 export type NavigationPosition = pb.GetLocationResponse.AsObject;
+export type Path = pb.Path.AsObject;


### PR DESCRIPTION
I need `navService.getPaths` in order to render paths in the navigation service RC card - I figured the easiest thing was just to quickly add it myself, but let me know if there's a better way to go about this!

## Change log

- Add `getPaths` to service client implementation and interface
- Add `Path` type to types definition
- `make bump-next-version`

## Review requests

- It looks like the pattern is to not add tests for simple pass-through RPCs. Is there a test I should add?
- Will the `next` version automatically get published to NPM?