### PR TITLE
RSDK-6016 - Add motion Expose Paths project RPC methods

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -320,7 +320,7 @@ export {
   type MotionConfiguration,
   type ObstacleDetector,
   type OrientationConstraint,
-  type PlanStateMap,
+  PlanState,
   MotionClient,
 } from './services/motion';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -311,13 +311,16 @@ export { default as inputControllerApi } from './gen/component/inputcontroller/v
  */
 export { default as motionApi } from './gen/service/motion/v1/motion_pb';
 export {
-  type Motion,
+  type CollisionSpecification,
   type Constraints,
+  type GetPlanResponse,
   type LinearConstraint,
+  type ListPlanStatusesResponse,
+  type Motion,
+  type MotionConfiguration,
   type ObstacleDetector,
   type OrientationConstraint,
-  type CollisionSpecification,
-  type MotionConfiguration,
+  type PlanStateMap,
   MotionClient,
 } from './services/motion';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -320,7 +320,7 @@ export {
   type MotionConfiguration,
   type ObstacleDetector,
   type OrientationConstraint,
-  PlanState,
+  type PlanState,
   MotionClient,
 } from './services/motion';
 

--- a/src/services/motion.ts
+++ b/src/services/motion.ts
@@ -6,5 +6,8 @@ export type {
   OrientationConstraint,
   CollisionSpecification,
   MotionConfiguration,
+  GetPlanResponse,
+  ListPlanStatusesResponse,
+  PlanStateMap,
 } from './motion/types';
 export { MotionClient } from './motion/client';

--- a/src/services/motion.ts
+++ b/src/services/motion.ts
@@ -8,6 +8,6 @@ export type {
   MotionConfiguration,
   GetPlanResponse,
   ListPlanStatusesResponse,
-  PlanStateMap,
+  PlanState,
 } from './motion/types';
 export { MotionClient } from './motion/client';

--- a/src/services/motion/client.test.ts
+++ b/src/services/motion/client.test.ts
@@ -1,0 +1,429 @@
+/*
+ *  @vitest-environment happy-dom
+ */
+
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
+import { MotionServiceClient } from '../../gen/service/motion/v1/motion_pb_service';
+import pb from '../../gen/service/motion/v1/motion_pb';
+import { RobotClient } from '../../robot';
+vi.mock('../../gen/service/motion/v1/motion_pb_service');
+vi.mock('../../robot');
+
+import { MotionClient } from './client';
+
+const motionClientName = 'test-motion';
+const date = new Date(1, 1, 1, 1, 1, 1);
+
+let motion: MotionClient;
+
+beforeEach(() => {
+  RobotClient.prototype.createServiceClient = vi
+    .fn()
+    .mockImplementation(() => new MotionServiceClient(motionClientName));
+
+  motion = new MotionClient(new RobotClient('host'), motionClientName);
+});
+
+const testExecutionId = 'some execution id';
+
+describe('moveOnGlobeNew', () => {
+  let executionId: Mock<[], string>;
+
+  test('return executionID', async () => {
+    executionId = vi.fn(() => testExecutionId);
+
+    const expectedMotionName = motionClientName;
+    const expectedDestination = { latitude: 1, longitude: 2 };
+    const expectedObstaclesList: Array<pb.ObstacleDetector> = [];
+    const expectedHeading = 0;
+    const expectedComponentName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'base',
+      name: 'myBase',
+    };
+    const expectedMovementSensorName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'movementsensor',
+      name: 'myMovementsensor',
+    };
+    const expectedMotionConfiguration = undefined;
+    const expectedExtra = {};
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.MoveOnGlobeNewRequest, _md, cb) => {
+        expect(req.getName()).toStrictEqual(expectedMotionName);
+        expect(req.getDestination()?.toObject()).toStrictEqual(
+          expectedDestination
+        );
+        expect(req.getHeading()).toStrictEqual(expectedHeading);
+        expect(req.getComponentName()?.toObject()).toStrictEqual(
+          expectedComponentName
+        );
+        expect(req.getMovementSensorName()?.toObject()).toStrictEqual(
+          expectedMovementSensorName
+        );
+        expect(req.getObstaclesList()).toEqual(expectedObstaclesList);
+        expect(req.getMotionConfiguration()).toStrictEqual(
+          expectedMotionConfiguration
+        );
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, {
+          toObject: () => ({
+            executionId: executionId(),
+          }),
+        });
+      });
+    MotionServiceClient.prototype.moveOnGlobeNew = mock;
+
+    await expect(
+      motion.moveOnGlobeNew(
+        { latitude: 1, longitude: 2 },
+        {
+          namespace: 'viam',
+          type: 'component',
+          subtype: 'base',
+          name: 'myBase',
+        },
+        {
+          namespace: 'viam',
+          type: 'component',
+          subtype: 'movementsensor',
+          name: 'myMovementsensor',
+        }
+      )
+    ).resolves.toStrictEqual(testExecutionId);
+
+    expect(mock).toHaveBeenCalledOnce();
+    expect(executionId).toHaveBeenCalledOnce();
+  });
+
+  test('allows optionally specifying heading, obstacles, motionConfig & extra', async () => {
+    executionId = vi.fn(() => testExecutionId);
+    const expectedMotionName = motionClientName;
+    const expectedDestination = { latitude: 1, longitude: 2 };
+    const expectedObstaclesList = [
+      {
+        location: { latitude: 3, longitude: 5 },
+        geometriesList: [
+          {
+            center: {
+              x: 1,
+              y: 2,
+              z: 3,
+              oX: 4,
+              oY: 5,
+              oZ: 6,
+              theta: 7,
+            },
+            sphere: { radiusMm: 100 },
+            label: 'my label',
+          },
+        ],
+      },
+    ];
+    const expectedHeading = 60;
+    const expectedComponentName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'base',
+      name: 'myBase',
+    };
+    const expectedMovementSensorName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'movementsensor',
+      name: 'myMovementsensor',
+    };
+    const expectedMotionConfiguration = {
+      obstacleDetectorsList: [
+        {
+          visionService: {
+            namespace: 'viam',
+            type: 'service',
+            subtype: 'vision',
+            name: 'myVisionService',
+          },
+          camera: {
+            namespace: 'viam',
+            type: 'component',
+            subtype: 'camera',
+            name: 'myCamera',
+          },
+        },
+      ],
+      positionPollingFrequencyHz: 20,
+      obstaclePollingFrequencyHz: 30,
+      planDeviationM: 2,
+      linearMPerSec: 2,
+      angularDegsPerSec: 180,
+    };
+    const expectedExtra = { some: 'extra' };
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.MoveOnGlobeNewRequest, _md, cb) => {
+        expect(req.getName()).toStrictEqual(expectedMotionName);
+        expect(req.getDestination()?.toObject()).toStrictEqual(
+          expectedDestination
+        );
+        expect(req.getHeading()).toStrictEqual(expectedHeading);
+        expect(req.getComponentName()?.toObject()).toStrictEqual(
+          expectedComponentName
+        );
+        expect(req.getMovementSensorName()?.toObject()).toStrictEqual(
+          expectedMovementSensorName
+        );
+        expect(req.getObstaclesList().map((x) => x.toObject())).toEqual(
+          expectedObstaclesList
+        );
+        expect(req.getMotionConfiguration()?.toObject()).toStrictEqual(
+          expectedMotionConfiguration
+        );
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, {
+          toObject: () => ({
+            executionId: executionId(),
+          }),
+        });
+      });
+
+    MotionServiceClient.prototype.moveOnGlobeNew = mock;
+    await expect(
+      motion.moveOnGlobeNew(
+        expectedDestination,
+        expectedComponentName,
+        expectedMovementSensorName,
+        expectedHeading,
+        expectedObstaclesList,
+        expectedMotionConfiguration,
+        expectedExtra
+      )
+    ).resolves.toStrictEqual(testExecutionId);
+    expect(mock).toHaveBeenCalledOnce();
+
+    expect(executionId).toHaveBeenCalledOnce();
+  });
+});
+
+describe('stopPlan', () => {
+  test('return null', async () => {
+    const expectedComponentName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'base',
+      name: 'myBase',
+    };
+    const expectedExtra = {};
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.StopPlanRequest, _md, cb) => {
+        expect(req.getComponentName()?.toObject()).toStrictEqual(
+          expectedComponentName
+        );
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, {});
+      });
+    MotionServiceClient.prototype.stopPlan = mock;
+    await expect(motion.stopPlan(expectedComponentName)).resolves.toStrictEqual(
+      null
+    );
+  });
+
+  test('allows optionally specifying extra', async () => {
+    const expectedComponentName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'base',
+      name: 'myBase',
+    };
+    const expectedExtra = { some: 'extra' };
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.StopPlanRequest, _md, cb) => {
+        expect(req.getComponentName()?.toObject()).toStrictEqual(
+          expectedComponentName
+        );
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, {});
+      });
+    MotionServiceClient.prototype.stopPlan = mock;
+    await expect(
+      motion.stopPlan(expectedComponentName, expectedExtra)
+    ).resolves.toStrictEqual(null);
+  });
+});
+
+describe('getPlan', () => {
+  const expectedResponse = {
+    toObject: () => ({
+      currentPlanWithStatus: {
+        plan: {
+          id: 'planId',
+          componentName: {
+            namespace: 'viam',
+            type: 'component',
+            subtype: 'base',
+            name: 'myBase',
+          },
+          executionId: 'executionId',
+          stepsList: [
+            [
+              'viam:component:base/myBase',
+              {
+                pose: {
+                  x: 10,
+                  y: 20,
+                  z: 30,
+                  oX: 40,
+                  oY: 50,
+                  oZ: 60,
+                  theta: 70,
+                },
+              },
+            ],
+          ],
+        },
+        status: {
+          status: pb.PlanState.PLAN_STATE_IN_PROGRESS,
+          timestamp: Timestamp.fromDate(date),
+        },
+        statusHistoryList: [],
+      },
+      replanHistoryList: [],
+    }),
+  };
+
+  test('return GetPlanResponse', async () => {
+    const expectedComponentName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'base',
+      name: 'myBase',
+    };
+    const expectedLastPlanOnly = false;
+    const expectedExecutionID = '';
+    const expectedExtra = {};
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.GetPlanRequest, _md, cb) => {
+        expect(req.getComponentName()?.toObject()).toStrictEqual(
+          expectedComponentName
+        );
+        expect(req.getLastPlanOnly()).toStrictEqual(expectedLastPlanOnly);
+        expect(req.getExecutionId()).toStrictEqual(expectedExecutionID);
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, expectedResponse);
+      });
+    MotionServiceClient.prototype.getPlan = mock;
+    await expect(motion.getPlan(expectedComponentName)).resolves.toStrictEqual(
+      expectedResponse.toObject()
+    );
+    expect(mock).toHaveBeenCalledOnce();
+  });
+
+  test('allows optionally specifying lastPlanOnly, executionID, and extra', async () => {
+    const expectedComponentName = {
+      namespace: 'viam',
+      type: 'component',
+      subtype: 'base',
+      name: 'myBase',
+    };
+    const expectedLastPlanOnly = true;
+    const expectedExecutionID = 'some specific executionID';
+    const expectedExtra = { some: 'extra' };
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.GetPlanRequest, _md, cb) => {
+        expect(req.getComponentName()?.toObject()).toStrictEqual(
+          expectedComponentName
+        );
+        expect(req.getLastPlanOnly()).toStrictEqual(expectedLastPlanOnly);
+        expect(req.getExecutionId()).toStrictEqual(expectedExecutionID);
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, expectedResponse);
+      });
+    MotionServiceClient.prototype.getPlan = mock;
+    await expect(
+      motion.getPlan(
+        expectedComponentName,
+        expectedLastPlanOnly,
+        expectedExecutionID,
+        expectedExtra
+      )
+    ).resolves.toStrictEqual(expectedResponse.toObject());
+    expect(mock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('listPlanStatuses', () => {
+  const expectedResponse = {
+    toObject: () => ({
+      planStatusesWithIdsList: [
+        {
+          planId: 'some plan id',
+          componentName: {
+            namespace: 'viam',
+            type: 'component',
+            subtype: 'base',
+            name: 'myBase',
+          },
+          executionId: 'some execution id',
+          state: pb.PlanState.PLAN_STATE_STOPPED,
+        },
+      ],
+    }),
+  };
+
+  test('return listPlanStatusesResponse', async () => {
+    const expectedOnlyActivePlans = false;
+    const expectedExtra = {};
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.ListPlanStatusesRequest, _md, cb) => {
+        expect(req.getOnlyActivePlans()).toStrictEqual(expectedOnlyActivePlans);
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, expectedResponse);
+      });
+    MotionServiceClient.prototype.listPlanStatuses = mock;
+    await expect(motion.listPlanStatuses()).resolves.toStrictEqual(
+      expectedResponse.toObject()
+    );
+    expect(mock).toHaveBeenCalledOnce();
+  });
+
+  test('allows optionally specifying onlyActivePlans and extra', async () => {
+    const expectedOnlyActivePlans = true;
+    const expectedExtra = { some: 'extra' };
+    const mock = vi
+      .fn()
+      .mockImplementation((req: pb.ListPlanStatusesRequest, _md, cb) => {
+        expect(req.getOnlyActivePlans()).toStrictEqual(expectedOnlyActivePlans);
+        expect(req.getExtra()?.toObject()).toStrictEqual(
+          Struct.fromJavaScript(expectedExtra)?.toObject()
+        );
+        cb(null, expectedResponse);
+      });
+    MotionServiceClient.prototype.listPlanStatuses = mock;
+    await expect(
+      motion.listPlanStatuses(expectedOnlyActivePlans, expectedExtra)
+    ).resolves.toStrictEqual(expectedResponse.toObject());
+    expect(mock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/services/motion/client.ts
+++ b/src/services/motion/client.ts
@@ -145,6 +145,110 @@ export class MotionClient implements Motion {
     return response.getSuccess();
   }
 
+  async moveOnGlobeNew(
+    destination: GeoPoint,
+    componentName: ResourceName,
+    movementSensorName: ResourceName,
+    heading?: number,
+    obstaclesList?: GeoObstacle[],
+    motionConfig?: MotionConfiguration,
+    extra = {}
+  ) {
+    const { service } = this;
+
+    const request = new pb.MoveOnGlobeNewRequest();
+    request.setName(this.name);
+    request.setDestination(encodeGeoPoint(destination));
+    request.setComponentName(encodeResourceName(componentName));
+    request.setMovementSensorName(encodeResourceName(movementSensorName));
+    if (heading) {
+      request.setHeading(heading);
+    }
+    if (obstaclesList) {
+      request.setObstaclesList(obstaclesList.map((x) => encodeGeoObstacle(x)));
+    }
+    if (motionConfig) {
+      request.setMotionConfiguration(encodeMotionConfiguration(motionConfig));
+    }
+    request.setExtra(Struct.fromJavaScript(extra));
+
+    this.options.requestLogger?.(request);
+
+    const response = await promisify<
+      pb.MoveOnGlobeNewRequest,
+      pb.MoveOnGlobeNewResponse
+    >(service.moveOnGlobeNew.bind(service), request);
+
+    return response.toObject().executionId;
+  }
+
+  async stopPlan(componentName: ResourceName, extra = {}) {
+    const { service } = this;
+
+    const request = new pb.StopPlanRequest();
+    request.setName(this.name);
+    request.setComponentName(encodeResourceName(componentName));
+    request.setExtra(Struct.fromJavaScript(extra));
+
+    this.options.requestLogger?.(request);
+
+    await promisify<pb.StopPlanRequest, pb.StopPlanResponse>(
+      service.stopPlan.bind(service),
+      request
+    );
+
+    return null;
+  }
+
+  async getPlan(
+    componentName: ResourceName,
+    lastPlanOnly?: boolean,
+    executionId?: string,
+    extra = {}
+  ) {
+    const { service } = this;
+
+    const request = new pb.GetPlanRequest();
+    request.setName(this.name);
+    request.setComponentName(encodeResourceName(componentName));
+    if (lastPlanOnly) {
+      request.setLastPlanOnly(lastPlanOnly);
+    }
+    if (executionId) {
+      request.setExecutionId(executionId);
+    }
+    request.setExtra(Struct.fromJavaScript(extra));
+
+    this.options.requestLogger?.(request);
+
+    const response = await promisify<pb.GetPlanRequest, pb.GetPlanResponse>(
+      service.getPlan.bind(service),
+      request
+    );
+
+    return response.toObject();
+  }
+
+  async listPlanStatuses(onlyActivePlans?: boolean, extra = {}) {
+    const { service } = this;
+
+    const request = new pb.ListPlanStatusesRequest();
+    request.setName(this.name);
+    if (onlyActivePlans) {
+      request.setOnlyActivePlans(onlyActivePlans);
+    }
+    request.setExtra(Struct.fromJavaScript(extra));
+
+    this.options.requestLogger?.(request);
+
+    const response = await promisify<
+      pb.ListPlanStatusesRequest,
+      pb.ListPlanStatusesResponse
+    >(service.listPlanStatuses.bind(service), request);
+
+    return response.toObject();
+  }
+
   async getPose(
     componentName: ResourceName,
     destinationFrame: string,

--- a/src/services/motion/motion.ts
+++ b/src/services/motion/motion.ts
@@ -9,7 +9,12 @@ import type {
   Transform,
   WorldState,
 } from '../../types';
-import type { Constraints, MotionConfiguration } from './types';
+import type {
+  Constraints,
+  MotionConfiguration,
+  GetPlanResponse,
+  ListPlanStatusesResponse,
+} from './types';
 
 /**
  * A service that coordinates motion planning across all of the components in a
@@ -77,6 +82,85 @@ export interface Motion extends Resource {
     motionConfiguration?: MotionConfiguration,
     extra?: StructType
   ) => Promise<boolean>;
+
+  /**
+   * Move a component to a specific latitude and longitude, using a
+   * `MovementSensor` to check the location. `moveOnGlobeNew()` is non blocking,
+   * meaning the motion service will move the component to the destination GPS
+   * point after `moveOnGlobeNew()` returns. Each successful `moveOnGlobeNew()`
+   * call retuns a unique ExectionID which you can use to identify all plans
+   * generated durring the `moveOnGlobeNew()` call. You can monitor the progress
+   * of the `moveOnGlobeNew()` call by querying `getPlan()` and
+   * `listPlanStatuses()`.
+   *
+   * @param destination - Destination for the component to move to, represented
+   *   as a `GeoPoint`.
+   * @param componentName - The name of the component to move.
+   * @param movementSensorName - The name of the `Movement Sensor` used to check
+   *   the robot's location.
+   * @param obstaclesList - Obstacles to consider when planning the motion of
+   *   the component.
+   * @param heading - Compass heading, in degrees, to achieve at destination.
+   * @param motionConfiguration - Optional motion configuration options.
+   */
+  moveOnGlobeNew: (
+    destination: GeoPoint,
+    componentName: ResourceName,
+    movementSensorName: ResourceName,
+    heading?: number,
+    obstaclesList?: GeoObstacle[],
+    motionConfiguration?: MotionConfiguration,
+    extra?: StructType
+  ) => Promise<string>;
+
+  /**
+   * Stop a component being moved by an in progress `moveOnGlobeNew()` call.
+   *
+   * @param componentName - The component to stop
+   */
+  stopPlan: (componentName: ResourceName, extra?: StructType) => Promise<null>;
+
+  /**
+   * By default: returns the plan history of the most recent
+   * `move_on_globe_new()` call to move a component. The plan history for
+   * executions before the most recent can be requested by providing an
+   * ExecutionID in the request. Returns a result if both of the following
+   * conditions are met:
+   *
+   * - The execution (call to `move_on_globe_new()`) is still executing **or**
+   *   changed state within the last 24 hours
+   * - The robot has not reinitialized Plans never change. Replans always create
+   *   new plans. Replans share the ExecutionID of the previously executing
+   *   plan. All repeated fields are in time ascending order.
+   *
+   * @param componentName - The component to query
+   * @param destinationFrame - The reference frame in which the component's
+   *   `Pose` should be provided, if unset this defaults to the "world"
+   *   reference frame.
+   * @param supplementalTransforms - `Pose` information on any additional
+   *   reference frames that are needed to compute the component's `Pose`.
+   */
+  getPlan: (
+    componentName: ResourceName,
+    lastPlanOnly?: boolean,
+    executionId?: string,
+    extra?: StructType
+  ) => Promise<GetPlanResponse>;
+
+  /**
+   * Get the current location and orientation of a component.
+   *
+   * @param componentName - The component whose `Pose` is being requested.
+   * @param destinationFrame - The reference frame in which the component's
+   *   `Pose` should be provided, if unset this defaults to the "world"
+   *   reference frame.
+   * @param supplementalTransforms - `Pose` information on any additional
+   *   reference frames that are needed to compute the component's `Pose`.
+   */
+  listPlanStatuses: (
+    onlyActivePlans?: boolean,
+    extra?: StructType
+  ) => Promise<ListPlanStatusesResponse>;
 
   /**
    * Get the current location and orientation of a component.

--- a/src/services/motion/types.ts
+++ b/src/services/motion/types.ts
@@ -9,7 +9,9 @@ export type CollisionSpecification = pb.CollisionSpecification.AsObject;
 export type MotionConfiguration = pb.MotionConfiguration.AsObject;
 export type GetPlanResponse = pb.GetPlanResponse.AsObject;
 export type ListPlanStatusesResponse = pb.ListPlanStatusesResponse.AsObject;
-export type PlanStateMap = pb.PlanStateMap;
+type ValueOf<T> = T[keyof T];
+export const { PlanState } = pb;
+export type PlanState = ValueOf<typeof pb.PlanState>;
 
 const encodeLinearConstraint = (
   obj: pb.LinearConstraint.AsObject

--- a/src/services/motion/types.ts
+++ b/src/services/motion/types.ts
@@ -7,6 +7,9 @@ export type LinearConstraint = pb.LinearConstraint.AsObject;
 export type OrientationConstraint = pb.OrientationConstraint.AsObject;
 export type CollisionSpecification = pb.CollisionSpecification.AsObject;
 export type MotionConfiguration = pb.MotionConfiguration.AsObject;
+export type GetPlanResponse = pb.GetPlanResponse.AsObject;
+export type ListPlanStatusesResponse = pb.ListPlanStatusesResponse.AsObject;
+export type PlanStateMap = pb.PlanStateMap;
 
 const encodeLinearConstraint = (
   obj: pb.LinearConstraint.AsObject

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,6 @@
 import type { JavaScriptValue } from 'google-protobuf/google/protobuf/struct_pb';
 
 import common from './gen/common/v1/common_pb';
-
 export type StructType = Record<string, JavaScriptValue>;
 
 export interface Options {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,6 +116,10 @@ export const encodeResourceName = (
 const encodeGeometry = (obj: common.Geometry.AsObject): common.Geometry => {
   const result = new common.Geometry();
 
+  if (obj.label) {
+    result.setLabel(obj.label);
+  }
+
   if (obj.center !== undefined) {
     result.setCenter(encodePose(obj.center));
   }


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6016)

### Changes:

- Add `moveOnGlobeNew`
- Add `stopPlan`
- Add `getPlan`
- Add `listPlanStatuses`
- Add tests for above

Follow up Breaking Change: https://github.com/viamrobotics/viam-typescript-sdk/pull/212