### PR TITLE
Include doCommandFromClient in bundle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -419,3 +419,5 @@ export type {
 } from './gen/robot/v1/robot_pb_service';
 
 export * from './types';
+
+export { doCommandFromClient } from './utils';


### PR DESCRIPTION
We want to use `doCommandFromClient` in the RC so we can expand the Do Command card to work for all components, not just generics. 