### PR TITLE
Ignore npm-check for rpc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ test-watch: $(node_modules) build-buf
 lint: $(node_modules) build-buf
 	npm run lint
 	npm run typecheck
-	npm run check
+	npm run check -- -i @viamrobotics/rpc
 
 .PHONY: format
 format: $(node_modules)

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ test-watch: $(node_modules) build-buf
 lint: $(node_modules) build-buf
 	npm run lint
 	npm run typecheck
+        // TODO(RSDK-5407): We can stop ignoring `@viamrobotics/rpc` once build issues are resolved in the latest version.
 	npm run check -- -i @viamrobotics/rpc
 
 .PHONY: format


### PR DESCRIPTION
For now, specifically ignore @viamrobotics/rpc in `npm-check`