### PR TITLE
[RSDK-6167] Update RPC library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,7 @@ test-watch: $(node_modules) build-buf
 lint: $(node_modules) build-buf
 	npm run lint
 	npm run typecheck
-	# TODO(RSDK-5407): We can stop ignoring `@viamrobotics/rpc` once build issues are resolved in the latest version.
-	npm run check -- -i @viamrobotics/rpc
+	npm run check
 
 .PHONY: format
 format: $(node_modules)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@viamrobotics/rpc": "^0.1.39",
+        "@viamrobotics/rpc": "^0.2.1",
         "exponential-backoff": "^3.1.1"
       },
       "devDependencies": {
@@ -26,9 +26,7 @@
         "copyfiles": "^2.4.1",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-sonarjs": "^0.23.0",
         "eslint-plugin-tsdoc": "^0.2.17",
-        "eslint-plugin-unicorn": "^49.0.0",
         "google-protobuf": "^3.21.2",
         "grpc-web": "^1.4.2",
         "happy-dom": "^8.2.6",
@@ -1667,9 +1665,9 @@
       }
     },
     "node_modules/@viamrobotics/rpc": {
-      "version": "0.1.39",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.1.39.tgz",
-      "integrity": "sha512-D5LP9PFh2/WcF4ELr4RlR6kaqYs4wIDr9sy2F+PxcOSN78msjAAoapgolmyIraFrgVOh3nosn/BtmiO74y1QNw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.2.1.tgz",
+      "integrity": "sha512-aPdL6UDOht1xerL/x+7LDevAmR9o/ZZSxlwl5y/SZcETA9BZk5LrqI66Jsr9RcdXqqsKeTRyZnhwu9PWwnO2RA==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",
         "google-protobuf": "^3.14.0"
@@ -2218,6 +2216,7 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       },
@@ -2518,6 +2517,7 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2527,6 +2527,7 @@
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
       "integrity": "sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -2539,6 +2540,7 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3776,6 +3778,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.23.0.tgz",
       "integrity": "sha512-z44T3PBf9W7qQ/aR+NmofOTyg6HLhSEZOPD4zhStqBpLoMp8GYhFksuUBnCxbnf1nfISpKBVkQhiBLFI/F4Wlg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3798,6 +3801,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-49.0.0.tgz",
       "integrity": "sha512-0fHEa/8Pih5cmzFW5L7xMEfUTvI9WKeQtjmKpTUmY+BiFCDxkxrTdnURJOHKykhtwIeyYsxnecbGvDCml++z4Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "@eslint-community/eslint-utils": "^4.4.0",
@@ -4979,6 +4983,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
       "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "builtin-modules": "^3.3.0"
       },
@@ -5251,6 +5256,7 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
       "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6748,6 +6754,7 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7184,6 +7191,7 @@
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
       "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "regexp-tree": "bin/regexp-tree"
       }
@@ -7217,6 +7225,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.10.0.tgz",
       "integrity": "sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "jsesc": "~0.5.0"
       },
@@ -7229,6 +7238,7 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
       "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jsesc": "bin/jsesc"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/viamrobotics/viam-typescript-sdk#readme",
   "dependencies": {
-    "@viamrobotics/rpc": "^0.1.39",
+    "@viamrobotics/rpc": "^0.2.1",
     "exponential-backoff": "^3.1.1"
   },
   "devDependencies": {

--- a/src/app/viam-transport.ts
+++ b/src/app/viam-transport.ts
@@ -1,5 +1,5 @@
 import { grpc } from '@improbable-eng/grpc-web';
-import { dialDirect } from '@viamrobotics/rpc/src/dial';
+import { dialDirect } from '@viamrobotics/rpc';
 
 import { AuthenticateRequest, Credentials } from '../gen/proto/rpc/v1/auth_pb';
 import { AuthServiceClient } from '../gen/proto/rpc/v1/auth_pb_service';

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import { backOff } from 'exponential-backoff';
-import type { Credentials, DialOptions } from '@viamrobotics/rpc/src/dial';
+import type { Credentials, DialOptions } from '@viamrobotics/rpc';
 import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import { dialDirect, dialWebRTC } from '@viamrobotics/rpc';
 import { grpc } from '@improbable-eng/grpc-web';


### PR DESCRIPTION
The package `@viamrobotics/rpc` was updated to a new version that now uses Vite. However, that introduced issues in the existing SDK. This PR address those issues:

* No longer imports from non-standard `/src/dial` file
* Updates the `@viamrobotics/eslint-config` package to keep up to date with the rest of our TS offerings
  * This involved updated many other outdated packages
  * This also involved fixing/disabling new ESLint errors that popped up

This requires the merge of https://github.com/viamrobotics/goutils/pull/227, followed by a new goutils release, after which we can reinstall/test the new RPC library