### PR TITLE
RSDK-6033 Add GetProperties to Nav and SLAM

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -14,8 +14,8 @@ deps:
   - remote: buf.build
     owner: viamrobotics
     repository: api
-    commit: d4ec998750154664b07085ccddc01004
-    digest: shake256:a3e0ed3e4f297aed633fed2933eed320615433e201893b5cda28d116752359db920474cd89b9106281c616942efc7452c60f72c61480feed4b3d4a3c58b3458e
+    commit: 6d25055f17a14c8282175dedb55857bc
+    digest: shake256:76809af680890d0047c28c03efe796a88421e61a4f0b2171979ba12e8d67ba14d40c94bcf0b93fd8ae285b7190a62270fd48e9c490839e303223bad5e43c725f
   - remote: buf.build
     owner: viamrobotics
     repository: goutils

--- a/src/main.ts
+++ b/src/main.ts
@@ -367,7 +367,11 @@ export { type Servo, ServoClient } from './components/servo';
  * @group Raw Protobufs
  */
 export { default as slamApi } from './gen/service/slam/v1/slam_pb';
-export { type SlamPosition, SlamProperties, SlamClient } from './services/slam';
+export {
+  type SlamPosition,
+  type SlamProperties,
+  SlamClient,
+} from './services/slam';
 
 /**
  * Raw Protobuf interfaces for a Vision service.

--- a/src/main.ts
+++ b/src/main.ts
@@ -340,6 +340,7 @@ export {
   type ModeMap,
   type Waypoint,
   type NavigationPosition,
+  type NavigationProperties,
   type Path,
   NavigationClient,
 } from './services/navigation';
@@ -366,7 +367,7 @@ export { type Servo, ServoClient } from './components/servo';
  * @group Raw Protobufs
  */
 export { default as slamApi } from './gen/service/slam/v1/slam_pb';
-export { type SlamPosition, SlamClient } from './services/slam';
+export { type SlamPosition, SlamProperties, SlamClient } from './services/slam';
 
 /**
  * Raw Protobuf interfaces for a Vision service.

--- a/src/services/navigation.ts
+++ b/src/services/navigation.ts
@@ -4,5 +4,6 @@ export type {
   Waypoint,
   NavigationPosition,
   Path,
+  NavigationProperties,
 } from './navigation/types';
 export { NavigationClient } from './navigation/client';

--- a/src/services/navigation/client.ts
+++ b/src/services/navigation/client.ts
@@ -168,6 +168,23 @@ export class NavigationClient implements Navigation {
     return response.getPathsList().map((x) => x.toObject());
   }
 
+  async getProperties(extra = {}) {
+    const { service } = this;
+
+    const request = new pb.GetPropertiesRequest();
+    request.setName(this.name);
+    request.setExtra(Struct.fromJavaScript(extra));
+
+    this.options.requestLogger?.(request);
+
+    const response = await promisify<pb.GetPropertiesRequest, pb.GetPropertiesResponse>(
+      service.getMode.bind(service),
+      request
+    );
+
+    return response.getProperties();
+  }
+
   async doCommand(command: StructType): Promise<StructType> {
     const { service } = this;
     return doCommandFromClient(service, this.name, command, this.options);

--- a/src/services/navigation/client.ts
+++ b/src/services/navigation/client.ts
@@ -168,12 +168,11 @@ export class NavigationClient implements Navigation {
     return response.getPathsList().map((x) => x.toObject());
   }
 
-  async getProperties(extra = {}) {
+  async getProperties() {
     const { service } = this;
 
     const request = new pb.GetPropertiesRequest();
     request.setName(this.name);
-    request.setExtra(Struct.fromJavaScript(extra));
 
     this.options.requestLogger?.(request);
 

--- a/src/services/navigation/client.ts
+++ b/src/services/navigation/client.ts
@@ -176,12 +176,12 @@ export class NavigationClient implements Navigation {
 
     this.options.requestLogger?.(request);
 
-    const response = await promisify<pb.GetPropertiesRequest, pb.GetPropertiesResponse>(
-      service.getMode.bind(service),
-      request
-    );
+    const response = await promisify<
+      pb.GetPropertiesRequest,
+      pb.GetPropertiesResponse
+    >(service.getProperties.bind(service), request);
 
-    return response.getProperties();
+    return response.toObject();
   }
 
   async doCommand(command: StructType): Promise<StructType> {

--- a/src/services/navigation/navigation.ts
+++ b/src/services/navigation/navigation.ts
@@ -57,5 +57,5 @@ export interface Navigation extends Resource {
   /** 
    * Gets information on the properties of the current navigation service. 
    */
-  getProperties: (id: string) => Promise<NavigationProperties>;
+  getProperties: () => Promise<NavigationProperties>;
 }

--- a/src/services/navigation/navigation.ts
+++ b/src/services/navigation/navigation.ts
@@ -1,14 +1,18 @@
 import type { GeoObstacle, GeoPoint, Resource, StructType } from '../../types';
-import type { ModeMap, Waypoint, NavigationPosition, NavigationProperties, Path } from './types';
+import type {
+  ModeMap,
+  Waypoint,
+  NavigationPosition,
+  NavigationProperties,
+  Path,
+} from './types';
 
 /**
  * A service that uses GPS to automatically navigate a robot to user defined
  * endpoints.
  */
 export interface Navigation extends Resource {
-  /** 
-   * Get the mode the robot is operating in. 
-   */
+  /** Get the mode the robot is operating in. */
   getMode: (extra?: StructType) => Promise<ModeMap[keyof ModeMap]>;
 
   /**
@@ -18,14 +22,10 @@ export interface Navigation extends Resource {
    */
   setMode: (mode: ModeMap[keyof ModeMap], extra?: StructType) => Promise<void>;
 
-  /** 
-   * Get the current location of the robot. 
-   */
+  /** Get the current location of the robot. */
   getLocation: (extra?: StructType) => Promise<NavigationPosition>;
 
-  /** 
-   * Get an array of waypoints currently in the service's data storage. 
-   */
+  /** Get an array of waypoints currently in the service's data storage. */
   getWayPoints: (extra?: StructType) => Promise<Waypoint[]>;
 
   /**
@@ -44,18 +44,12 @@ export interface Navigation extends Resource {
    */
   removeWayPoint: (id: string, extra?: StructType) => Promise<void>;
 
-  /** 
-   * Get a list of obstacles. 
-   */
+  /** Get a list of obstacles. */
   getObstacles: (extra?: StructType) => Promise<GeoObstacle[]>;
 
-  /** 
-   * Gets the list of paths known to the navigation service. 
-   */
+  /** Gets the list of paths known to the navigation service. */
   getPaths: (extra?: StructType) => Promise<Path[]>;
 
-  /** 
-   * Gets information on the properties of the current navigation service. 
-   */
+  /** Gets information on the properties of the current navigation service. */
   getProperties: () => Promise<NavigationProperties>;
 }

--- a/src/services/navigation/navigation.ts
+++ b/src/services/navigation/navigation.ts
@@ -1,12 +1,14 @@
 import type { GeoObstacle, GeoPoint, Resource, StructType } from '../../types';
-import type { ModeMap, Waypoint, NavigationPosition, Path } from './types';
+import type { ModeMap, Waypoint, NavigationPosition, NavigationProperties, Path } from './types';
 
 /**
  * A service that uses GPS to automatically navigate a robot to user defined
  * endpoints.
  */
 export interface Navigation extends Resource {
-  /** Get the mode the robot is operating in. */
+  /** 
+   * Get the mode the robot is operating in. 
+   */
   getMode: (extra?: StructType) => Promise<ModeMap[keyof ModeMap]>;
 
   /**
@@ -16,10 +18,14 @@ export interface Navigation extends Resource {
    */
   setMode: (mode: ModeMap[keyof ModeMap], extra?: StructType) => Promise<void>;
 
-  /** Get the current location of the robot. */
+  /** 
+   * Get the current location of the robot. 
+   */
   getLocation: (extra?: StructType) => Promise<NavigationPosition>;
 
-  /** Get an array of waypoints currently in the service's data storage. */
+  /** 
+   * Get an array of waypoints currently in the service's data storage. 
+   */
   getWayPoints: (extra?: StructType) => Promise<Waypoint[]>;
 
   /**
@@ -38,9 +44,18 @@ export interface Navigation extends Resource {
    */
   removeWayPoint: (id: string, extra?: StructType) => Promise<void>;
 
-  /** Get a list of obstacles. */
+  /** 
+   * Get a list of obstacles. 
+   */
   getObstacles: (extra?: StructType) => Promise<GeoObstacle[]>;
 
-  /** Gets the list of paths known to the navigation service. */
+  /** 
+   * Gets the list of paths known to the navigation service. 
+   */
   getPaths: (extra?: StructType) => Promise<Path[]>;
+
+  /** 
+   * Gets information on the properties of the current navigation service. 
+   */
+  getProperties: (id: string) => Promise<NavigationProperties>;
 }

--- a/src/services/navigation/types.ts
+++ b/src/services/navigation/types.ts
@@ -4,3 +4,4 @@ export type ModeMap = pb.ModeMap;
 export type Waypoint = pb.Waypoint.AsObject;
 export type NavigationPosition = pb.GetLocationResponse.AsObject;
 export type Path = pb.Path.AsObject;
+export type NavigationProperties = pb.GetPropertiesResponse.AsObject;

--- a/src/services/slam.ts
+++ b/src/services/slam.ts
@@ -1,3 +1,3 @@
 export type { Slam } from './slam/slam';
-export type { SlamPosition } from './slam/types';
+export type { SlamPosition, SlamProperties } from './slam/types';
 export { SlamClient } from './slam/client';

--- a/src/services/slam/client.ts
+++ b/src/services/slam/client.ts
@@ -158,7 +158,7 @@ export class SlamClient implements Slam {
     const response = await promisify<
       pb.GetPropertiesRequest,
       pb.GetPropertiesResponse
-    >(service.getPosition.bind(service), request);
+    >(service.getProperties.bind(service), request);
 
     return response.toObject();
   }

--- a/src/services/slam/client.ts
+++ b/src/services/slam/client.ts
@@ -147,6 +147,22 @@ export class SlamClient implements Slam {
     return new Date(timestamp.getSeconds() * 1e3 + timestamp.getNanos() / 1e6);
   }
 
+  async getProperties() {
+    const { service } = this;
+
+    const request = new pb.GetPropertiesRequest();
+    request.setName(this.name);
+
+    this.options.requestLogger?.(request);
+
+    const response = await promisify<
+      pb.GetPropertiesRequest,
+      pb.GetPropertiesResponse
+    >(service.getPosition.bind(service), request);
+
+    return response.toObject();
+  }
+
   async doCommand(command: StructType): Promise<StructType> {
     const { service } = this;
     return doCommandFromClient(service, this.name, command, this.options);

--- a/src/services/slam/slam.ts
+++ b/src/services/slam/slam.ts
@@ -1,5 +1,5 @@
 import type { Resource } from '../../types';
-import type { SlamPosition } from './types';
+import type { SlamPosition, SlamProperties } from './types';
 
 /**
  * A service that allows your robot to create a map of its surroundings and find
@@ -12,7 +12,9 @@ export interface Slam extends Resource {
    */
   getPosition: () => Promise<SlamPosition>;
 
-  /** Get the point cloud SLAM map. */
+  /** 
+   * Get the point cloud SLAM map. 
+   */
   getPointCloudMap: () => Promise<Uint8Array>;
 
   /**
@@ -21,6 +23,13 @@ export interface Slam extends Resource {
    */
   getInternalState: () => Promise<Uint8Array>;
 
-  /** Get the timestamp of the last update to the point cloud SLAM map. */
+  /** 
+   * Get the timestamp of the last update to the point cloud SLAM map. 
+   */
   getLatestMapInfo: () => Promise<Date>;
+
+  /** 
+   * Gets information on the properties of the current SLAM service. 
+   */
+  getProperties: () => Promise<SlamProperties>;
 }

--- a/src/services/slam/slam.ts
+++ b/src/services/slam/slam.ts
@@ -12,9 +12,7 @@ export interface Slam extends Resource {
    */
   getPosition: () => Promise<SlamPosition>;
 
-  /** 
-   * Get the point cloud SLAM map. 
-   */
+  /** Get the point cloud SLAM map. */
   getPointCloudMap: () => Promise<Uint8Array>;
 
   /**
@@ -23,13 +21,9 @@ export interface Slam extends Resource {
    */
   getInternalState: () => Promise<Uint8Array>;
 
-  /** 
-   * Get the timestamp of the last update to the point cloud SLAM map. 
-   */
+  /** Get the timestamp of the last update to the point cloud SLAM map. */
   getLatestMapInfo: () => Promise<Date>;
 
-  /** 
-   * Gets information on the properties of the current SLAM service. 
-   */
+  /** Gets information on the properties of the current SLAM service. */
   getProperties: () => Promise<SlamProperties>;
 }

--- a/src/services/slam/types.ts
+++ b/src/services/slam/types.ts
@@ -1,3 +1,4 @@
 import pb from '../../gen/service/slam/v1/slam_pb';
 
 export type SlamPosition = pb.GetPositionResponse.AsObject;
+export type SlamProperties = pb.GetPropertiesResponse.AsObject;


### PR DESCRIPTION
This PR adds the GetProperties endpoints for both the slam and navigation services in viam's typescript sdk. The new endpoint was added in [this](https://github.com/viamrobotics/api/commit/223673cee35c340ea2fb40b742680c5104abdafc) commit to the API.

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-6033