### PR TITLE
export promisify util

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -418,4 +418,4 @@ export type {
 
 export * from './types';
 
-export { doCommandFromClient } from './utils';
+export { doCommandFromClient, promisify } from './utils';


### PR DESCRIPTION
In order to create custom API bindings, this needs to be exported.