### PR TITLE
Export disconnect and reconnect events

### DIFF
--- a/examples/vanilla/src/main.ts
+++ b/examples/vanilla/src/main.ts
@@ -57,13 +57,13 @@ async function run(client: VIAM.RobotClient) {
 
 // This function is called when the robot is disconnected.
 // Feel free to replace it with whatever logic you want to test out!
-async function disconnected(event) {
+async function disconnected() {
   console.log('The robot has been disconnected. Trying reconnect...');
 }
 
 // This function is called when the robot is reconnected.
 // Feel free to replace it with whatever logic you want to test out!
-async function reconnected(event) {
+async function reconnected() {
   console.log('The robot has been reconnected. Work can be continued.');
 }
 
@@ -73,8 +73,8 @@ async function main() {
   try {
     client = await connect();
     console.log('connected!');
-    client.on('disconnected', disconnected);
-    client.on('reconnected', reconnected);
+    client.on(VIAM.MachineConnectionEvent.DISCONNECTED, disconnected);
+    client.on(VIAM.MachineConnectionEvent.RECONNECTED, reconnected);
   } catch (error) {
     console.log(error);
     return;

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,7 +1,15 @@
 type Callback = (args: unknown) => void;
 
-export const RECONNECTED = 'reconnected';
-export const DISCONNECTED = 'disconnected';
+/**
+ * MachineConnectionEvent events are emitted by a Client's EventDispatcher when
+ * connection events occur.
+ *
+ * TODO: Emit 'connecting' and 'connected' events
+ */
+export enum MachineConnectionEvent {
+  RECONNECTED = 'reconnected',
+  DISCONNECTED = 'disconnected',
+}
 
 export class EventDispatcher {
   listeners: Partial<Record<string, Set<Callback>>> = {};

--- a/src/extra/stream/client.ts
+++ b/src/extra/stream/client.ts
@@ -1,4 +1,4 @@
-import { EventDispatcher, events } from '../../events';
+import { EventDispatcher, MachineConnectionEvent, events } from '../../events';
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { StreamServiceClient } from '../../gen/proto/stream/v1/stream_pb_service';
@@ -39,7 +39,7 @@ export class StreamClient extends EventDispatcher implements Stream {
       this.emit('track', args);
     });
 
-    events.on('reconnected', () => {
+    events.on(MachineConnectionEvent.RECONNECTED, () => {
       for (const name of this.streams.values()) {
         void this.add(name);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -475,3 +475,8 @@ export type {
 export * from './types';
 
 export { doCommandFromClient, promisify } from './utils';
+
+export {
+  RECONNECTED,
+  DISCONNECTED,
+} from './events';

--- a/src/main.ts
+++ b/src/main.ts
@@ -476,7 +476,4 @@ export * from './types';
 
 export { doCommandFromClient, promisify } from './utils';
 
-export {
-  RECONNECTED,
-  DISCONNECTED,
-} from './events';
+export { MachineConnectionEvent } from './events';

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -9,7 +9,7 @@ import {
 import { backOff } from 'exponential-backoff';
 import { Duration } from 'google-protobuf/google/protobuf/duration_pb';
 import { DIAL_TIMEOUT } from '../constants';
-import { DISCONNECTED, EventDispatcher, RECONNECTED, events } from '../events';
+import { EventDispatcher, MachineConnectionEvent, events } from '../events';
 import type {
   PoseInFrame,
   ResourceName,
@@ -171,11 +171,11 @@ export class RobotClient extends EventDispatcher implements Robot {
       }
     );
 
-    events.on(RECONNECTED, () => {
-      this.emit(RECONNECTED, {});
+    events.on(MachineConnectionEvent.RECONNECTED, () => {
+      this.emit(MachineConnectionEvent.RECONNECTED, {});
     });
-    events.on(DISCONNECTED, () => {
-      this.emit(DISCONNECTED, {});
+    events.on(MachineConnectionEvent.DISCONNECTED, () => {
+      this.emit(MachineConnectionEvent.DISCONNECTED, {});
       if (this.noReconnect) {
         return;
       }
@@ -189,7 +189,7 @@ export class RobotClient extends EventDispatcher implements Robot {
             () => {
               // eslint-disable-next-line no-console
               console.debug('reconnected successfully!');
-              events.emit(RECONNECTED, {});
+              events.emit(MachineConnectionEvent.RECONNECTED, {});
             },
             (error) => {
               // eslint-disable-next-line no-console
@@ -476,9 +476,9 @@ export class RobotClient extends EventDispatcher implements Robot {
            * recover.
            */
           if (this.peerConn?.iceConnectionState === 'connected') {
-            events.emit(RECONNECTED, {});
+            events.emit(MachineConnectionEvent.RECONNECTED, {});
           } else if (this.peerConn?.iceConnectionState === 'closed') {
-            events.emit(DISCONNECTED, {});
+            events.emit(MachineConnectionEvent.DISCONNECTED, {});
           }
         });
 

--- a/src/robot/grpc-connection-manager.ts
+++ b/src/robot/grpc-connection-manager.ts
@@ -1,7 +1,7 @@
 import { grpc } from '@improbable-eng/grpc-web';
 import { RobotServiceClient } from '../gen/robot/v1/robot_pb_service';
 import robotApi from '../gen/robot/v1/robot_pb';
-import { DISCONNECTED, events } from '../events';
+import { MachineConnectionEvent, events } from '../events';
 import { type ServiceError } from '../gen/robot/v1/robot_pb_service';
 
 const timeoutBlob = new Blob(
@@ -43,7 +43,7 @@ export default class GRPCConnectionManager {
         new grpc.Metadata(),
         (err) => {
           if (err) {
-            events.emit(DISCONNECTED, {});
+            events.emit(MachineConnectionEvent.DISCONNECTED, {});
             return;
           }
 

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -4,7 +4,7 @@ import type {
   Transform,
 } from '../gen/common/v1/common_pb';
 import type { StructType } from '../types';
-import { DISCONNECTED, RECONNECTED } from '../events';
+import { MachineConnectionEvent } from '../events';
 import type proto from '../gen/robot/v1/robot_pb';
 import type { ResponseStream } from '../gen/robot/v1/robot_pb_service';
 
@@ -161,10 +161,7 @@ export interface Robot {
    * @param listener - The function to call
    * @alpha
    */
-  on: (
-    type: typeof RECONNECTED | typeof DISCONNECTED,
-    listener: Callback
-  ) => void;
+  on: (type: MachineConnectionEvent, listener: Callback) => void;
 
   /**
    * Get app-related information about the robot.


### PR DESCRIPTION
See https://github.com/viamrobotics/app/pull/4672. I need to listen to the disconnect and reconnect events - I could hardcode the strings, but it would be more convenient if I could just import the constants.

I'm not tied to this, so please let me know if this isn't the right way to go about it!