### PR TITLE
RSDK-7244: Emit disconnect events on data channel close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@viamrobotics/rpc": "^0.2.4",
+        "@viamrobotics/rpc": "^0.2.5",
         "exponential-backoff": "^3.1.1"
       },
       "devDependencies": {
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@viamrobotics/rpc": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.2.4.tgz",
-      "integrity": "sha512-AMUGxplDfM9wzOEse0WYEsPeYJzGeyI5TbOAeXsi+0f9EueTd0bGuIjaBKDceBlK/x+JMc0nxOrfdfDwN18UmQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@viamrobotics/rpc/-/rpc-0.2.5.tgz",
+      "integrity": "sha512-kvMffJhMQGAiPc5fA7wRZaEeYw2MDtBavkv0GllBNgKaGaK/JhIUMJrZsIl1oGLP15AMiv/MLUPmQ0yWttc5eA==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.13.0",
         "google-protobuf": "^3.14.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/viamrobotics/viam-typescript-sdk#readme",
   "dependencies": {
-    "@viamrobotics/rpc": "^0.2.4",
+    "@viamrobotics/rpc": "^0.2.5",
     "exponential-backoff": "^3.1.1"
   },
   "devDependencies": {

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -481,6 +481,12 @@ export class RobotClient extends EventDispatcher implements Robot {
             events.emit(MachineConnectionEvent.DISCONNECTED, {});
           }
         });
+        // There is not an iceconnectionstatechange nor connectionstatechange
+        // event when the peerConn closes. Instead, listen to the data channel
+        // closing and emit disconnect when that occurs.
+        webRTCConn.dataChannel.addEventListener('close', (event) => {
+          events.emit(MachineConnectionEvent.DISCONNECTED, event);
+        });
 
         this.transportFactory = webRTCConn.transportFactory;
 


### PR DESCRIPTION
This fixes RSDK-7244, which describes how the TS SDK does not attempt reconnect when a disconnect occurs.

The TS SDK attempts to reconnect to the peer in a [backoff loop](https://github.com/viamrobotics/viam-typescript-sdk/blob/f49f6857de9277f72f1e4894b985ea976ae51ea0/src/robot/client.ts#L186). This happens whenever a [disconnect event](https://github.com/viamrobotics/viam-typescript-sdk/blob/f49f6857de9277f72f1e4894b985ea976ae51ea0/src/robot/client.ts#L177) occurs.

The TS SDK currently listens to `iceconnectionstatechange` `close` events on the `RTCPeerConnection` to [emit the disconnect](https://github.com/viamrobotics/viam-typescript-sdk/blob/f49f6857de9277f72f1e4894b985ea976ae51ea0/src/robot/client.ts#L469-L483) necessary to start the reconnection. These events are never being emitted, as confirmed with browser WebRTC logging. `connectionstatechange` events are not emitted either.

Instead, we must listen to the `RTCDataChannel` `close` events which is actually what goutils [already does](https://github.com/viamrobotics/goutils/blob/612b3f81b6b71c94b89805e63390b6ec5336d8ca/rpc/js/src/ClientChannel.ts#L38) to know when to close the `RTCPeerConnection`.

https://github.com/viamrobotics/goutils/pull/287: exposes the `RTCDataChannel`
https://github.com/viamrobotics/viam-typescript-sdk/pull/291: **this PR** listens to `close` events on the `RTCDataChannel`

### TODO

- [x] Bump to `@viamrobotics/rpc@0.2.5` once https://github.com/viamrobotics/goutils/pull/287 is merged and published

### PR stack

Additional changes are stacked on top of this PR but are not necessary for the disconnect fix.

1. https://github.com/viamrobotics/viam-typescript-sdk/pull/291
2. https://github.com/viamrobotics/viam-typescript-sdk/pull/292
3. https://github.com/viamrobotics/viam-typescript-sdk/pull/294