### PR TITLE
Enable workflows for all pull requests

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -1,9 +1,6 @@
 name: Pull Request Update
 
-on:
-  workflow_dispatch:
-  pull_request:
-    branches: [main, 'rc-*']
+on: [workflow_dispatch, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Let me know what you think about this change - we do the same thing in App as well. This makes it so we can stack PRs but still have workflows run on all PRs in the stack. I'm flexible, let me know if this change doesn't make sense!