### PR TITLE
RSDK-7413: Remove global event dispatcher

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -42,5 +42,3 @@ export class EventDispatcher {
     }
   }
 }
-
-export const events = new EventDispatcher();

--- a/src/extra/stream/client.test.ts
+++ b/src/extra/stream/client.test.ts
@@ -4,24 +4,25 @@ import { vi, beforeEach, afterEach, describe, expect, it } from 'vitest';
 import { RobotClient } from '../../robot';
 vi.mock('../../robot');
 
-import { events } from '../../events';
 import { StreamServiceClient } from '../../gen/proto/stream/v1/stream_pb_service';
 vi.mock('../../gen/proto/stream/v1/stream_pb_service');
 
 import { StreamClient } from './client';
-
-let streamClient: StreamClient;
+import { EventDispatcher } from '../../events';
 
 describe('StreamClient', () => {
+  let robotClient: RobotClient;
+  let streamClient: StreamClient;
+
   beforeEach(() => {
     vi.useFakeTimers();
 
     const fakehost = 'fakehost';
-    RobotClient.prototype.createServiceClient = vi
+
+    robotClient = new EventDispatcher() as RobotClient;
+    robotClient.createServiceClient = vi
       .fn()
       .mockImplementation(() => new StreamServiceClient(fakehost));
-
-    const robotClient = new RobotClient(fakehost);
     streamClient = new StreamClient(robotClient);
   });
 
@@ -36,7 +37,7 @@ describe('StreamClient', () => {
         done();
       });
 
-      events.emit('track', { mock: true });
+      robotClient.emit('track', { mock: true });
     }));
 
   it('getStream creates and returns a new stream', async () => {

--- a/src/extra/stream/client.ts
+++ b/src/extra/stream/client.ts
@@ -1,4 +1,4 @@
-import { EventDispatcher, MachineConnectionEvent, events } from '../../events';
+import { EventDispatcher, MachineConnectionEvent } from '../../events';
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { StreamServiceClient } from '../../gen/proto/stream/v1/stream_pb_service';
@@ -35,11 +35,11 @@ export class StreamClient extends EventDispatcher implements Stream {
      * future we'll want to partition here and have individual events for each
      * stream.
      */
-    events.on('track', (args) => {
+    client.on('track', (args) => {
       this.emit('track', args);
     });
 
-    events.on(MachineConnectionEvent.RECONNECTED, () => {
+    client.on(MachineConnectionEvent.RECONNECTED, () => {
       for (const name of this.streams.values()) {
         void this.add(name);
       }


### PR DESCRIPTION
This removes the global `EventDispatcher` instance and makes each `RobotClient` responsible for its own event dispatching.

1. https://github.com/viamrobotics/viam-typescript-sdk/pull/291
2. https://github.com/viamrobotics/viam-typescript-sdk/pull/292
3. https://github.com/viamrobotics/viam-typescript-sdk/pull/294

## Change log

- Remove the global `EventDispatcher`
- Clean up instances of calling `events.emit` and `events.on`
- Pass `onDisconnect` handler to `GrpcConnectionManager`
- Fix up tests

## Testing

- Unit tests
- `examples/connect-app` locally