### PR TITLE
Emit connectionstatechange events

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -3,11 +3,11 @@ type Callback = (args: unknown) => void;
 /**
  * MachineConnectionEvent events are emitted by a Client's EventDispatcher when
  * connection events occur.
- *
- * TODO: Emit 'connecting' and 'connected' events
  */
 export enum MachineConnectionEvent {
-  RECONNECTED = 'reconnected',
+  CONNECTING = 'connecting',
+  CONNECTED = 'connected',
+  DISCONNECTING = 'disconnecting',
   DISCONNECTED = 'disconnected',
 }
 

--- a/src/extra/stream/client.ts
+++ b/src/extra/stream/client.ts
@@ -39,7 +39,7 @@ export class StreamClient extends EventDispatcher implements Stream {
       this.emit('track', args);
     });
 
-    client.on(MachineConnectionEvent.RECONNECTED, () => {
+    client.on(MachineConnectionEvent.CONNECTED, () => {
       for (const name of this.streams.values()) {
         void this.add(name);
       }

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -173,6 +173,12 @@ export class RobotClient extends EventDispatcher implements Robot {
         return this.transportFactory(opts);
       }
     );
+
+    for (const eventType of Object.values(MachineConnectionEvent)) {
+      this.on(eventType, () => {
+        this.emit('connectionstatechange', { eventType });
+      });
+    }
   }
 
   private onDisconnect(event?: Event) {
@@ -199,7 +205,6 @@ export class RobotClient extends EventDispatcher implements Robot {
       .then(() => {
         // eslint-disable-next-line no-console
         console.debug('Reconnected successfully!');
-        this.emit(MachineConnectionEvent.RECONNECTED, {});
       })
       .catch(() => {
         // eslint-disable-next-line no-console
@@ -376,6 +381,7 @@ export class RobotClient extends EventDispatcher implements Robot {
   }
 
   public async disconnect() {
+    this.emit(MachineConnectionEvent.DISCONNECTING, {});
     while (this.connecting) {
       // eslint-disable-next-line no-await-in-loop
       await this.connecting;
@@ -386,18 +392,23 @@ export class RobotClient extends EventDispatcher implements Robot {
       this.peerConn = undefined;
     }
     this.sessionManager.reset();
+    this.emit(MachineConnectionEvent.DISCONNECTED, {});
   }
 
   public isConnected(): boolean {
     return this.peerConn?.iceConnectionState === 'connected';
   }
 
+  // TODO: refactor due to cognitive complexity
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   public async connect({
     authEntity = this.savedAuthEntity,
     creds = this.savedCreds,
     priority,
     dialTimeout,
   }: ConnectOptions = {}) {
+    this.emit(MachineConnectionEvent.CONNECTING, {});
+
     if (this.connecting) {
       // This lint is clearly wrong due to how the event loop works such that after an await, the condition may no longer be true.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -470,7 +481,7 @@ export class RobotClient extends EventDispatcher implements Robot {
            * recover.
            */
           if (this.peerConn?.iceConnectionState === 'connected') {
-            this.emit(MachineConnectionEvent.RECONNECTED, {});
+            this.emit(MachineConnectionEvent.CONNECTED, {});
           } else if (this.peerConn?.iceConnectionState === 'closed') {
             this.onDisconnect();
           }
@@ -586,6 +597,14 @@ export class RobotClient extends EventDispatcher implements Robot {
         this.serviceHost,
         grpcOptions
       );
+
+      this.emit(MachineConnectionEvent.CONNECTED, {});
+    } catch (error) {
+      // Need to catch the error to properly emit disconnect but
+      // also throw the error so reconnect backoff keeps retrying.
+      // TODO(ethanlook): clean this up
+      this.emit(MachineConnectionEvent.DISCONNECTED, {});
+      throw error;
     } finally {
       this.connectResolve?.();
       this.connectResolve = undefined;

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -174,6 +174,13 @@ export class RobotClient extends EventDispatcher implements Robot {
       }
     );
 
+    // For each connection event type, add a listener to capture that
+    // event and re-emit it with the 'connectionstatechange' event
+    // name. This makes it so consumers can listen to all connection
+    // state change events without needing to individually subscribe
+    // to all of them. 'connectionstatechange' should not be emitted
+    // directly. Instead, the RobotClient implementation should emit
+    // MachineConnectionEvents.
     for (const eventType of Object.values(MachineConnectionEvent)) {
       this.on(eventType, () => {
         this.emit('connectionstatechange', { eventType });
@@ -399,7 +406,7 @@ export class RobotClient extends EventDispatcher implements Robot {
     return this.peerConn?.iceConnectionState === 'connected';
   }
 
-  // TODO: refactor due to cognitive complexity
+  // TODO(RSDK-7672): refactor due to cognitive complexity
   // eslint-disable-next-line sonarjs/cognitive-complexity
   public async connect({
     authEntity = this.savedAuthEntity,

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -152,16 +152,22 @@ export interface Robot {
   ): RobotStatusStream;
 
   /**
-   * Call a function when an event of either 'reconnected' or 'disconnected' is
-   * triggered. Note that these events will only be triggered on WebRTC
-   * connections.
+   * Call a function when a connection event occurs.
    *
-   * @param type - The event ('reconnected' or 'disconnected') that was
-   *   triggered.
+   * Note that direct gRPC connections that disconnect will not emit a
+   * disconnect event. WebRTC connections that disconnect will emit a disconnect
+   * event. All connections emit events during manual calls of `connect` and
+   * `disconnect`.
+   *
+   * @param type - The event MachineConnectionEvent that was triggered, or all
+   *   connection events with 'connectionstatechange'.
    * @param listener - The function to call
    * @alpha
    */
-  on: (type: MachineConnectionEvent, listener: Callback) => void;
+  on: (
+    type: MachineConnectionEvent | 'connectionstatechange',
+    listener: Callback
+  ) => void;
 
   /**
    * Get app-related information about the robot.


### PR DESCRIPTION
This adds `connectionstatechange` events to the `RobotClient` such that a consumer only has to listen to one thing to get all of the connection events.

Example:

```
let connectionState = 'disconnected';

// Need to mark 'connecting' and 'connected' by yourself on the initial connection since we can't listen to events until createRobotClient resolves.
connectionState = 'connecting';
const machine = VIAM.createRobotClient({ ... });
connectionState = 'connected';

machine.on('connectionstatechange', (event) => {
  connectionState = (event as { eventType: MachineConnectionState }).eventType;
});
```

To best see this in action, check out the follow-up PR to add a new vanilla example for using the robot client. I used this for testing during local development. (The existing vanilla example uses the Viam client.)

1. ➡️ https://github.com/viamrobotics/viam-typescript-sdk/pull/299
2. https://github.com/viamrobotics/viam-typescript-sdk/pull/300

## Change log

- Update the possible `MachineConnectionEvent`s: `connecting | connected | disconnecting | disconnected`
  - I got rid of `reconnected`. AFAICT it was just used internally, but please let me know if that assumption is false. Because of how reconnect logic is structured using `connect()`, it would be messy to emit a different event during `reconnecting` and `reconnected`.
- For `connect()` - emit `connecting` at start and `connected` if successful. `disconnected` is still emitted when there is a failure.
- For `disconnect()` - emit `disconnecting` at start and `disconnected` if successful.
  - `disconnecting -> disconnect` isn't humanly perceivable under the conditions I was testing in, but I think it's good practice to emit to the consumer
- Expose `connectionstatechange` event on `RobotClient`s