### PR TITLE
RSDK-7470: Add GetProperties and CaptureAllFromCamera

### DIFF
--- a/src/services/vision/types.ts
+++ b/src/services/vision/types.ts
@@ -1,6 +1,30 @@
 import pb from '../../gen/service/vision/v1/vision_pb';
 import commonPB from '../../gen/common/v1/common_pb';
+import cameraPB from '../../gen/component/camera/v1/camera_pb';
 
 export type Detection = pb.Detection.AsObject;
 export type Classification = pb.Classification.AsObject;
 export type PointCloudObject = commonPB.PointCloudObject.AsObject;
+
+export interface Properties {
+  /** Whether or not classifactions are supported by the vision service */
+  classificationsSupported: boolean;
+  /** Whether or not detections are supported by the vision service */
+  detectionsSupported: boolean;
+  /** Whether or not 3d segmentation is supported by the vision service */
+  objectPointCloudsSupported: boolean;
+}
+
+export interface CaptureAllOptions {
+  returnImage: boolean;
+  returnClassifications: boolean;
+  returnDetections: boolean;
+  returnObjectPointClouds: boolean;
+}
+
+export interface CaptureAllResponse {
+  image: cameraPB.Image.AsObject | undefined;
+  classifications: Classification[];
+  detections: Detection[];
+  objectPointClouds: PointCloudObject[];
+}

--- a/src/services/vision/vision.ts
+++ b/src/services/vision/vision.ts
@@ -1,6 +1,13 @@
 import type { MimeType } from '../../main';
 import type { Resource, StructType } from '../../types';
-import type { Classification, Detection, PointCloudObject } from './types';
+import type {
+  Classification,
+  Detection,
+  PointCloudObject,
+  Properties,
+  CaptureAllOptions,
+  CaptureAllResponse,
+} from './types';
 
 /** A service that enables various computer vision algorithms */
 export interface Vision extends Resource {
@@ -75,4 +82,29 @@ export interface Vision extends Resource {
     cameraName: string,
     extra?: StructType
   ) => Promise<PointCloudObject[]>;
+
+  /**
+   * Returns an object describing the properties of the vision service, namely
+   * booleans indicating whether classifications, detections, and 3d
+   * segmentation are supported.
+   *
+   * @returns - The properties of the vision service
+   */
+  getProperties: (extra?: StructType) => Promise<Properties>;
+
+  /**
+   * Returns the requested image, classifications, detections, and 3d point
+   * cloud objects in the next image given a camera.
+   *
+   * @param cameraName - The name of the camera to use for classification,
+   *   detection, and segmentation.
+   * @param opts - The fields desired in the response.
+   * @returns - The requested image, classifications, detections, and 3d point
+   *   cloud objects.
+   */
+  captureAllFromCamera: (
+    cameraName: string,
+    opts: CaptureAllOptions,
+    extra?: StructType
+  ) => Promise<CaptureAllResponse>;
 }


### PR DESCRIPTION
This adds `GetProperties` and `CaptureAllFromCamera` to the vision service client, which will be used for the new vision service control card.

cc @micheal-parks @bhaney 

## Testing

Unit tests