### PR TITLE
RSDK-7987 - Arm should re-export JointPositions type from proto

### DIFF
--- a/src/components/arm.ts
+++ b/src/components/arm.ts
@@ -1,2 +1,2 @@
-export type { Arm } from './arm/arm';
+export type { Arm, ArmJointPositions } from './arm/arm';
 export { ArmClient } from './arm/client';

--- a/src/components/arm/arm.ts
+++ b/src/components/arm/arm.ts
@@ -2,7 +2,7 @@ import type { JointPositions } from '../../gen/component/arm/v1/arm_pb';
 
 import type { Pose, Resource, StructType } from '../../types';
 
-export type ArmJointPositions = JointPositions;
+export type ArmJointPositions = JointPositions.AsObject;
 
 /** Represents a physical robot arm that exists in three-dimensional space. */
 export interface Arm extends Resource {

--- a/src/components/arm/arm.ts
+++ b/src/components/arm/arm.ts
@@ -2,6 +2,8 @@ import type { JointPositions } from '../../gen/component/arm/v1/arm_pb';
 
 import type { Pose, Resource, StructType } from '../../types';
 
+export type ArmJointPositions = JointPositions;
+
 /** Represents a physical robot arm that exists in three-dimensional space. */
 export interface Arm extends Resource {
   /** Get the position of the end of the arm expressed as a pose */
@@ -26,7 +28,7 @@ export interface Arm extends Resource {
   ) => Promise<void>;
 
   /** Gets the current position of each joint. */
-  getJointPositions: (extra?: StructType) => Promise<JointPositions>;
+  getJointPositions: (extra?: StructType) => Promise<ArmJointPositions>;
 
   /** Stops the motion of the arm. */
   stop: (extra?: StructType) => Promise<void>;

--- a/src/components/arm/client.ts
+++ b/src/components/arm/client.ts
@@ -99,7 +99,7 @@ export class ArmClient implements Arm {
     if (!result) {
       throw new Error('no pose');
     }
-    return result;
+    return result.toObject();
   }
 
   async stop(extra = {}) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,7 +120,7 @@ export { type BillingClient } from './app/billing-client';
  * @group Raw Protobufs
  */
 export { default as armApi } from './gen/component/arm/v1/arm_pb';
-export { type Arm, ArmClient } from './components/arm';
+export { type Arm, type ArmJointPositions, ArmClient } from './components/arm';
 
 /**
  * Raw Protobuf interfaces for a Base component.


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-7987

This follows the pattern from Encoder which also wraps the encoder `pb.PositionType` with a new `EncoderPositionType`