### PR TITLE
Add the ability to abort an initial connection attempt

### DIFF
--- a/examples/vanilla/package-lock.json
+++ b/examples/vanilla/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../..": {
       "name": "@viamrobotics/sdk",
-      "version": "0.16.0",
+      "version": "0.19.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@viamrobotics/rpc": "^0.2.5",

--- a/examples/vanilla/src/main.ts
+++ b/examples/vanilla/src/main.ts
@@ -12,6 +12,7 @@ const disconnectEl = <HTMLButtonElement>document.getElementById('disconnect');
 const resourcesEl = <HTMLButtonElement>document.getElementById('resources');
 
 let machine: VIAM.RobotClient | undefined = undefined;
+const reconnectAbort = { abort: false };
 
 const handleConnectionStateChange = (event: unknown) => {
   updateConnectionStatus(
@@ -42,6 +43,7 @@ const connect = async () => {
     return;
   }
 
+  reconnectAbort.abort = false;
   updateConnectionStatus(VIAM.MachineConnectionEvent.CONNECTING);
 
   try {
@@ -53,6 +55,7 @@ const connect = async () => {
       },
       authEntity: API_KEY_ID,
       signalingAddress: 'https://app.viam.com:443',
+      reconnectAbort,
     });
     updateConnectionStatus(VIAM.MachineConnectionEvent.CONNECTED);
     machine.on('connectionstatechange', handleConnectionStateChange);
@@ -62,6 +65,9 @@ const connect = async () => {
 };
 
 const disconnect = async () => {
+  // If currently establishing initial connection, abort.
+  reconnectAbort.abort = true;
+
   if (!machine) {
     return;
   }

--- a/examples/vanilla/src/main.ts
+++ b/examples/vanilla/src/main.ts
@@ -12,7 +12,7 @@ const disconnectEl = <HTMLButtonElement>document.getElementById('disconnect');
 const resourcesEl = <HTMLButtonElement>document.getElementById('resources');
 
 let machine: VIAM.RobotClient | undefined = undefined;
-const reconnectAbort = { abort: false };
+const reconnectAbortSignal = { abort: false };
 
 const handleConnectionStateChange = (event: unknown) => {
   updateConnectionStatus(
@@ -43,7 +43,7 @@ const connect = async () => {
     return;
   }
 
-  reconnectAbort.abort = false;
+  reconnectAbortSignal.abort = false;
   updateConnectionStatus(VIAM.MachineConnectionEvent.CONNECTING);
 
   try {
@@ -55,7 +55,7 @@ const connect = async () => {
       },
       authEntity: API_KEY_ID,
       signalingAddress: 'https://app.viam.com:443',
-      reconnectAbort,
+      reconnectAbortSignal,
     });
     updateConnectionStatus(VIAM.MachineConnectionEvent.CONNECTED);
     machine.on('connectionstatechange', handleConnectionStateChange);
@@ -66,7 +66,7 @@ const connect = async () => {
 
 const disconnect = async () => {
   // If currently establishing initial connection, abort.
-  reconnectAbort.abort = true;
+  reconnectAbortSignal.abort = true;
 
   if (!machine) {
     return;

--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -16,7 +16,7 @@ export interface DialDirectConf {
   noReconnect?: boolean;
   reconnectMaxAttempts?: number;
   reconnectMaxWait?: number;
-  reconnectAbort?: { abort: boolean };
+  reconnectAbortSignal?: { abort: boolean };
   // set timeout in milliseconds for dialing. Default is defined by DIAL_TIMEOUT,
   // and a value of 0 would disable the timeout.
   dialTimeout?: number;
@@ -89,7 +89,7 @@ export interface DialWebRTCConf {
   noReconnect?: boolean;
   reconnectMaxAttempts?: number;
   reconnectMaxWait?: number;
-  reconnectAbort?: { abort: boolean };
+  reconnectAbortSignal?: { abort: boolean };
   // WebRTC
   signalingAddress: string;
   iceServers?: ICEServer[];
@@ -182,12 +182,12 @@ export const createRobotClient = async (
       console.debug(`Failed to connect, attempt ${attemptNumber} with backoff`);
 
       // Abort reconnects if the the caller specifies, otherwise retry
-      return !conf.reconnectAbort?.abort;
+      return !conf.reconnectAbortSignal?.abort;
     },
   };
 
   // Try to dial via WebRTC first.
-  if (isDialWebRTCConf(conf) && !conf.reconnectAbort?.abort) {
+  if (isDialWebRTCConf(conf) && !conf.reconnectAbortSignal?.abort) {
     try {
       return conf.noReconnect
         ? await dialWebRTC(conf)
@@ -198,7 +198,7 @@ export const createRobotClient = async (
     }
   }
 
-  if (!conf.reconnectAbort?.abort) {
+  if (!conf.reconnectAbortSignal?.abort) {
     try {
       return conf.noReconnect
         ? await dialDirect(conf)


### PR DESCRIPTION
I discovered this while working with an offline robot - if you're making your initial connection with retries, there was previously no ability to abort the reconnect attempts once they started. This allows the user to pass in an object with the rest of the dial options that they can later cancel.

## Change log

- Add `reconnectAbort` option to `DialOpts`
- Do not retry if `reconnectAbort.abort` is true
- Update `vanilla` example with usage

## Tested

- Vanilla example
- Used in app, observed behavior is resolved!