### PR TITLE
Return Uint8Array image from captureAllFromCamera

### DIFF
--- a/src/services/vision/client.ts
+++ b/src/services/vision/client.ts
@@ -189,8 +189,17 @@ export class VisionClient implements Vision {
       pb.CaptureAllFromCameraRequest,
       pb.CaptureAllFromCameraResponse
     >(service.captureAllFromCamera.bind(service), request);
+
+    const image = response.getImage();
+
     return {
-      image: response.getImage()?.toObject(),
+      image: image
+        ? {
+            format: image.getFormat(),
+            sourceName: image.getSourceName(),
+            image: image.getImage_asU8(),
+          }
+        : undefined,
       classifications: response
         .getClassificationsList()
         .map((classification: pb.Classification) => classification.toObject()),


### PR DESCRIPTION
### Overview

Currently captureAllFromCamera returns a base64 encoded image from `captureAllFromCamera`. This PR updates the method implementation so that a more efficient `Uint8Array` is returned instead.