### PR TITLE
Update apis.json to match new values

### DIFF
--- a/codesamples/apis.json
+++ b/codesamples/apis.json
@@ -1,69 +1,84 @@
 {
-    "arm": {
-        "client": "ArmClient",
-        "func": "getEndPosition",
-        "args": []
-    },
-    "base": {
-        "client": "BaseClient",
-        "func": "isMoving"
-    },
-    "motor": {
-        "client": "MotorClient",
-        "func": "isMoving",
-        "args": []
-    },
-    "board": {
-        "client": "BoardClient",
-        "func": "getGPIO",
-        "args": [
-            "'16'"
-        ],
-        "comment": "Note that the pin supplied is a placeholder. Please change this to a valid pin you are using."
-    },
-    "camera": {
-        "client": "CameraClient",
-        "func": "getImage",
-        "args": []
-    },
-    "encoder": {
-        "client": "EncoderClient",
-        "func": "getProperties",
-        "args": []
-    },
-    "gantry": {
-        "client": "GantryClient",
-        "func": "getLengths",
-        "args": []
-    },
-    "sensor": {
-        "client": "SensorClient",
-        "func": "getReadings",
-        "args": []
-    },
-    "movement_sensor": {
-        "client": "MovementSensorClient",
-        "func": "getLinearAcceleration",
-        "args": []
-    },
-    "power_sensor": {
-        "client": "PowerSensorClient",
-        "func": "getPower",
-        "args": []
-    },
-    "servo": {
-        "client": "ServoClient",
-        "func": "getPosition"
-    },
-    "motion": {
-        "client": "MotionClient",
-        "func": "getPose",
-        "args": [],
-        "comment": "Note this function requires additional arguments. Please provide valid arguments for function to work properly."
-    },
-    "data_manager": {
-        "client": "DataManagerClient",
-        "func": "sync",
-        "args": []
-    }
+  "arm": {
+    "importName": "ArmClient",
+    "func": "getEndPosition",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "base": {
+    "importName": "BaseClient",
+    "func": "isMoving",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "motor": {
+    "importName": "MotorClient",
+    "func": "isMoving",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "board": {
+    "importName": "BoardClient",
+    "func": "getGPIO",
+    "args": ["'16'"],
+    "comment": "Note that the pin supplied is a placeholder. Please change this to a valid pin you are using.",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "camera": {
+    "importName": "CameraClient",
+    "func": "getImage",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "encoder": {
+    "importName": "EncoderClient",
+    "func": "getProperties",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "gantry": {
+    "importName": "GantryClient",
+    "func": "getLengths",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "sensor": {
+    "importName": "SensorClient",
+    "func": "getReadings",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "movement_sensor": {
+    "importName": "MovementSensorClient",
+    "func": "getLinearAcceleration",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "power_sensor": {
+    "importName": "PowerSensorClient",
+    "func": "getPower",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "servo": {
+    "importName": "ServoClient",
+    "func": "getPosition",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "motion": {
+    "importName": "MotionClient",
+    "func": "getPose",
+    "args": [],
+    "comment": "Note this function requires additional arguments. Please provide valid arguments for function to work properly.",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  },
+  "data_manager": {
+    "importName": "DataManagerClient",
+    "func": "sync",
+    "packagePath": "@viamrobotics/sdk",
+    "packageName": "VIAM"
+  }
 }


### PR DESCRIPTION
Updates the `apis.json` file to use the new fields we use for code sample generation. See similar changes for the [Python SDK](https://github.com/viamrobotics/viam-python-sdk/pull/635) and [RDK](https://github.com/viamrobotics/rdk/pull/4180). 

It's important to note the TS-SDK had a departure from other SDKs where it declared a `client` field. I have updated that to use `importName` to match other code sample implementations.

Another callout is the addition of these two, currently repetitive, fields:

```json
{
  ...
  "packagePath": "@viamrobotics/sdk",
  "packageName": "VIAM"
}
```

We are using these to generate a singular import statement of:

```ts
import * as VIAM from "@viamrobotics/sdk";
```

With these new fields, it would be trivial to allow breaking up these important to sub-modules if that happens in the future, for example (not using valid paths):

```json
{
  ...
  "board": {
    "importName": "BoardClient",
    "func": "getGPIO",
    "args": ["'16'"],
    "comment": "Note that the pin supplied is a placeholder. Please change this to a valid pin you are using.",
    "packagePath": "@viamrobotics/sdk/components/",
    "packageName": "board"
  },
  "camera": {
    "importName": "CameraClient",
    "func": "getImage",
    "packagePath": "@viamrobotics/sdk/components/",
    "packageName": "camera"
  },
  ...
  "motion": {
    "importName": "MotionClient",
    "func": "getPose",
    "args": [],
    "comment": "Note this function requires additional arguments. Please provide valid arguments for function to work properly.",
    "packagePath": "@viamrobotics/sdk/services/",
    "packageName": "motion"
  },
  ...
}
```

```ts
import { BoardClient } from "@viamrobotics/sdk/components/board";
import { CameraClient } from "@viamrobotics/sdk/components/camera";
import { MotionClient } from "@viamrobotics/sdk/services/motion";
```
