### PR TITLE
Add `getSessions` Wrapper to RobotClient

### DIFF
--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -631,6 +631,18 @@ export class RobotClient extends EventDispatcher implements Robot {
     }
   }
 
+  // SESSIONS
+
+  async getSessions() {
+    const { robotService } = this;
+    const request = new proto.GetSessionsRequest();
+    const response = await promisify<
+      proto.GetSessionsRequest,
+      proto.GetSessionsResponse
+    >(robotService.getSessions.bind(robotService), request);
+    return response.getSessionsList().map((session) => session.toObject());
+  }
+
   // OPERATIONS
 
   async getOperations() {

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -15,6 +15,14 @@ type Callback = (args: unknown) => void;
 
 export interface Robot {
   /**
+   * Get the list of sessions currently connected to the robot.
+   *
+   * @group Sessions
+   * @alpha
+   */
+  getSessions(): Promise<proto.Session.AsObject[]>;
+
+  /**
    * Get the list of operations currently running on the robot.
    *
    * @group Operations


### PR DESCRIPTION
Imported into app and tested that the type signatures are correct (have not manually run it yet)

Used `proto.Session.AsObject[]` instead of `proto.Session[]` because I've seen a lot of the api wrappers move to the .AsObject form. 

However, `GetOperations` still returns the `proto.Operation[]` form, so for consistency also happy to swap over to that.