### PR TITLE
RSDK-8156: binaryDataCaptureUpload and tabularDataCaptureUpload actually do require dataRequestTimes

### DIFF
--- a/src/app/data-client.test.ts
+++ b/src/app/data-client.test.ts
@@ -1036,8 +1036,8 @@ describe('DataSyncClient tests', () => {
         componentType,
         componentName,
         methodName,
-        tags,
-        [dataRequestTimes1, dataRequestTimes2]
+        [dataRequestTimes1, dataRequestTimes2],
+        tags
       );
       expect(methodSpy).toHaveBeenCalledWith(
         expectedRequest,
@@ -1080,8 +1080,8 @@ describe('DataSyncClient tests', () => {
         componentName,
         methodName,
         fileExtension,
-        tags,
-        dataRequestTimes1
+        dataRequestTimes1,
+        tags
       );
       expect(methodSpy).toHaveBeenCalledWith(
         expectedRequest,

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -793,10 +793,10 @@ export class DataClient {
     componentType: string,
     componentName: string,
     methodName: string,
-    tags?: string[],
-    dataRequestTimes?: [Date, Date][]
+    dataRequestTimes: [Date, Date][],
+    tags?: string[]
   ) {
-    if (dataRequestTimes?.length !== tabularData.length) {
+    if (dataRequestTimes.length !== tabularData.length) {
       throw new Error('dataRequestTimes and data lengths must be equal.');
     }
 
@@ -868,8 +868,8 @@ export class DataClient {
     componentName: string,
     methodName: string,
     fileExtension: string,
-    tags?: string[],
-    dataRequestTimes?: [Date, Date]
+    dataRequestTimes: [Date, Date],
+    tags?: string[]
   ) {
     const { dataSyncService: service } = this;
 
@@ -886,10 +886,8 @@ export class DataClient {
 
     const sensorData = new dataSyncPb.SensorData();
     const sensorMetadata = new dataSyncPb.SensorMetadata();
-    if (dataRequestTimes) {
-      sensorMetadata.setTimeRequested(Timestamp.fromDate(dataRequestTimes[0]));
-      sensorMetadata.setTimeReceived(Timestamp.fromDate(dataRequestTimes[1]));
-    }
+    sensorMetadata.setTimeRequested(Timestamp.fromDate(dataRequestTimes[0]));
+    sensorMetadata.setTimeReceived(Timestamp.fromDate(dataRequestTimes[1]));
     sensorData.setMetadata(sensorMetadata);
     sensorData.setBinary(binaryData);
 


### PR DESCRIPTION
-remove optionality of `dataRequestTime` parameter in `binaryDataCaptureUpload` and `tabularDataCaptureUpload `
-had to switch ordering of `tags` and `dataRequestTime` parameters as a required parameter cannot come after an optional parameter and `tags` is optional