### PR TITLE
Add closed bool to prevent reconnection

### DIFF
--- a/examples/vanilla/package-lock.json
+++ b/examples/vanilla/package-lock.json
@@ -19,10 +19,10 @@
     },
     "../..": {
       "name": "@viamrobotics/sdk",
-      "version": "0.19.1",
+      "version": "0.23.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@viamrobotics/rpc": "^0.2.5",
+        "@viamrobotics/rpc": "^0.2.6",
         "exponential-backoff": "^3.1.1"
       },
       "devDependencies": {

--- a/examples/vanilla/src/main.ts
+++ b/examples/vanilla/src/main.ts
@@ -52,6 +52,7 @@ const connect = async () => {
       credential: {
         type: 'api-key',
         payload: API_KEY,
+        authEntity: API_KEY_ID,
       },
       authEntity: API_KEY_ID,
       signalingAddress: 'https://app.viam.com:443',


### PR DESCRIPTION
When `disconnect` is called, set a `closed` boolean to prevent auto-reconnection. the `closed` boolean is reset when the user/sdk actively attempts to connect again