### PR TITLE
RSDK-8989 - Always provide error on base channel close

### DIFF
--- a/src/rpc/base-channel.ts
+++ b/src/rpc/base-channel.ts
@@ -40,10 +40,6 @@ export class BaseChannel {
     });
   }
 
-  public close() {
-    this.closeWithReason(undefined);
-  }
-
   public isClosed() {
     return this.closed;
   }
@@ -52,7 +48,7 @@ export class BaseChannel {
     return this.closedReason;
   }
 
-  protected closeWithReason(err?: Error) {
+  public closeWithReason(err: Error) {
     if (this.closed) {
       return;
     }

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -402,7 +402,7 @@ export const dialWebRTC = async (
     if (dialOpts?.dialTimeout !== undefined) {
       setTimeout(() => {
         if (!successful) {
-          exchange.terminate();
+          exchange.terminate(new Error('timed out'));
         }
       }, dialOpts.dialTimeout);
     }

--- a/src/rpc/signaling-exchange.ts
+++ b/src/rpc/signaling-exchange.ts
@@ -73,7 +73,7 @@ export class SignalingExchange {
       .then(() => {
         this.exchangeDone = true;
       })
-      .catch(console.error); // eslint-disable-line no-console
+      .catch(console.error);
 
     // Initiate now the call now that all of our handlers are setup.
     const callResponses = this.signalingClient.call(callRequest, this.callOpts);
@@ -127,8 +127,8 @@ export class SignalingExchange {
     }
   }
 
-  public terminate() {
-    this.clientChannel.close();
+  public terminate(err: Error) {
+    this.clientChannel.closeWithReason(err);
   }
 
   private async processCallResponses(


### PR DESCRIPTION
@zaporter-work fwiw, this has been a bug prior to the new connect-es migration

<img width="751" alt="Screenshot 2024-10-15 at 11 12 45 AM" src="https://github.com/user-attachments/assets/9fb33f20-1c48-4f8d-9716-9acd58b92de1">
