### PR TITLE
RSDK-9147: Change Typescript TabularDataBySQL/MQL return type to raw BSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@bufbuild/protobuf": "^1.10.0",
         "@connectrpc/connect": "^1.6.0",
         "@connectrpc/connect-web": "^1.6.0",
+        "bsonfy": "^1.0.2",
         "exponential-backoff": "^3.1.1"
       },
       "devDependencies": {
@@ -2280,6 +2281,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/bsonfy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bsonfy/-/bsonfy-1.0.2.tgz",
+      "integrity": "sha512-/kLM6B2x/CWXdkTu2kAv65trB4YruwahBpFDxYkkSunve6Rvx7KSoSHHe1f4jsPXPgXvDG393IjkQ3Us645Eag==",
+      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@bufbuild/protobuf": "^1.10.0",
     "@connectrpc/connect": "^1.6.0",
     "@connectrpc/connect-web": "^1.6.0",
+    "bsonfy": "^1.0.2",
     "exponential-backoff": "^3.1.1"
   },
   "devDependencies": {

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -72,6 +72,7 @@ import {
   UploadMetadata,
 } from '../gen/app/datasync/v1/data_sync_pb';
 import { DataClient, type FilterOptions } from './data-client';
+import { DateTime } from '../gen/google/type/datetime_pb';
 vi.mock('../gen/app/data/v1/data_pb_service');
 
 let mockTransport: Transport;
@@ -87,6 +88,7 @@ describe('DataClient tests', () => {
   const lastId = 'lastId';
   const countOnly = true;
   const includeInternalData = false;
+  const startDate = new Date(1, 1, 1, 1, 1, 1);
 
   const binaryId1 = new BinaryID({
     fileId: 'testFileId1',
@@ -100,8 +102,9 @@ describe('DataClient tests', () => {
   });
 
   describe('tabularDataBySQL tests', () => {
-    const data: Record<string, JsonValue>[] = [
-      { key1: 1, key2: '2', key3: [1, 2, 3], key4: { key4sub1: 1 } },
+    type returnType = JsonValue | Date;
+    const data: Record<string, returnType>[] = [
+      { key1: startDate, key2: '2', key3: [1, 2, 3], key4: { key4sub1: 1 } },
     ];
 
     beforeEach(() => {
@@ -109,7 +112,6 @@ describe('DataClient tests', () => {
         service(DataService, {
           tabularDataBySQL: () => {
             return new TabularDataBySQLResponse({
-              // data: data.map((x) => Struct.fromJson(x)),
               rawData: data.map((x) => BSON.serialize(x)),
             });
           },
@@ -127,8 +129,9 @@ describe('DataClient tests', () => {
   });
 
   describe('tabularDataByMQL tests', () => {
-    const data: Record<string, JsonValue>[] = [
-      { key1: 1, key2: '2', key3: [1, 2, 3], key4: { key4sub1: 1 } },
+    type returnType = JsonValue | Date;
+    const data: Record<string, returnType>[] = [
+      { key1: startDate, key2: '2', key3: [1, 2, 3], key4: { key4sub1: 1 } },
     ];
 
     beforeEach(() => {
@@ -136,7 +139,7 @@ describe('DataClient tests', () => {
         service(DataService, {
           tabularDataByMQL: () => {
             return new TabularDataByMQLResponse({
-              data: data.map((x) => Struct.fromJson(x)),
+              rawData: data.map((x) => BSON.serialize(x)),
             });
           },
         });

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -123,6 +123,8 @@ describe('DataClient tests', () => {
         'some_org_id',
         'some_sql_query'
       );
+      // @ts-ignore
+      expect(promise[0].key1).toBeInstanceOf(Date);
       expect(promise).toEqual(data);
     });
   });
@@ -149,6 +151,8 @@ describe('DataClient tests', () => {
       const promise = await subject().tabularDataByMQL('some_org_id', [
         new TextEncoder().encode('some_mql_query'),
       ]);
+      // @ts-ignore
+      expect(promise[0].key1).toBeInstanceOf(Date);
       expect(promise).toEqual(data);
     });
   });

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -124,7 +124,7 @@ describe('DataClient tests', () => {
         'some_sql_query'
       );
       const result = promise as typeof data;
-      expect(result[0].key1).toBeInstanceOf(Date);
+      expect(result[0]?.key1).toBeInstanceOf(Date);
       expect(promise).toEqual(data);
     });
   });
@@ -152,7 +152,7 @@ describe('DataClient tests', () => {
         new TextEncoder().encode('some_mql_query'),
       ]);
       const result = promise as typeof data;
-      expect(result[0].key1).toBeInstanceOf(Date);
+      expect(result[0]?.key1).toBeInstanceOf(Date);
       expect(promise).toEqual(data);
     });
   });

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -123,8 +123,8 @@ describe('DataClient tests', () => {
         'some_org_id',
         'some_sql_query'
       );
-      // @ts-ignore
-      expect(promise[0].key1).toBeInstanceOf(Date);
+      const result = promise as typeof data;
+      expect(result[0].key1).toBeInstanceOf(Date);
       expect(promise).toEqual(data);
     });
   });
@@ -151,8 +151,8 @@ describe('DataClient tests', () => {
       const promise = await subject().tabularDataByMQL('some_org_id', [
         new TextEncoder().encode('some_mql_query'),
       ]);
-      // @ts-ignore
-      expect(promise[0].key1).toBeInstanceOf(Date);
+      const result = promise as typeof data;
+      expect(result[0].key1).toBeInstanceOf(Date);
       expect(promise).toEqual(data);
     });
   });

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -72,7 +72,6 @@ import {
   UploadMetadata,
 } from '../gen/app/datasync/v1/data_sync_pb';
 import { DataClient, type FilterOptions } from './data-client';
-import { DateTime } from '../gen/google/type/datetime_pb';
 vi.mock('../gen/app/data/v1/data_pb_service');
 
 let mockTransport: Transport;

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -1,3 +1,4 @@
+import { BSON } from 'bsonfy'
 import { Struct, Timestamp, type JsonValue } from '@bufbuild/protobuf';
 import { createRouterTransport, type Transport } from '@connectrpc/connect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -108,7 +109,8 @@ describe('DataClient tests', () => {
         service(DataService, {
           tabularDataBySQL: () => {
             return new TabularDataBySQLResponse({
-              data: data.map((x) => Struct.fromJson(x)),
+              // data: data.map((x) => Struct.fromJson(x)),
+              rawData: data.map((x) => BSON.serialize(x)),
             });
           },
         });

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -1,4 +1,4 @@
-import { BSON } from 'bsonfy'
+import { BSON } from 'bsonfy';
 import { Struct, Timestamp, type JsonValue } from '@bufbuild/protobuf';
 import { createRouterTransport, type Transport } from '@connectrpc/connect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -1,3 +1,4 @@
+import { BSON } from 'bsonfy'
 import { Struct, Timestamp, type JsonValue } from '@bufbuild/protobuf';
 import {
   createPromiseClient,
@@ -64,7 +65,8 @@ export class DataClient {
       organizationId,
       sqlQuery: query,
     });
-    return resp.data.map((value) => value.toJson());
+    return resp.rawData.map((value) => BSON.deserialize(value));
+    // return resp.data.map((value) => value.toJson());
   }
 
   /**

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -66,7 +66,6 @@ export class DataClient {
       sqlQuery: query,
     });
     return resp.rawData.map((value) => BSON.deserialize(value));
-    // return resp.data.map((value) => value.toJson());
   }
 
   /**
@@ -81,7 +80,7 @@ export class DataClient {
       organizationId,
       mqlBinary: query,
     });
-    return resp.data.map((value) => value.toJson());
+    return resp.rawData.map((value) => BSON.deserialize(value));
   }
 
   /**

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -1,4 +1,4 @@
-import { BSON } from 'bsonfy'
+import { BSON } from 'bsonfy';
 import { Struct, Timestamp, type JsonValue } from '@bufbuild/protobuf';
 import {
   createPromiseClient,


### PR DESCRIPTION
For context: The return type of the TabularDataBySQL/MQL proto has changed to return both a list of structs, the existing return type, and also a list of bytearrays that represent BSON.

Added a required dependency to bsonfy to use the `BSON` library
BSON provides a deserialize() function for converting lists of byte sequences into lists of javascript objects.

**Testing:**
Updated the `data` testing input to include `Date` objects, as the Typescript SDK will receive date fields in this format. I added a check to ensure that `Date` inputs are returned as native typescript `Date` objects

I ensured that date fields are returned as native typescript Date objects instead of strings by running tabularDataByMQL against real tabular data on viam-dev and printed the decoded data and their types. As you can see below the date and time elements are of type "Date" (click on the photo for clarity)
![Screenshot 2024-10-31 at 1 33 08 PM](https://github.com/user-attachments/assets/46da6acc-d369-43d0-93ed-bf53baa943a9)