### PR TITLE
APP-6785: Allow different service host from webrtc host

### DIFF
--- a/src/robot/dial.ts
+++ b/src/robot/dial.ts
@@ -81,6 +81,7 @@ export interface DialWebRTCConf {
   reconnectMaxWait?: number;
   reconnectAbortSignal?: { abort: boolean };
   // WebRTC
+  serviceHost?: string;
   signalingAddress: string;
   iceServers?: ICEServer[];
   priority?: number;
@@ -94,7 +95,7 @@ const dialWebRTC = async (conf: DialWebRTCConf): Promise<RobotClient> => {
   // eslint-disable-next-line no-console
   console.debug('dialing via WebRTC...');
 
-  const impliedURL = conf.host;
+  const impliedURL = conf.serviceHost ?? conf.host;
   const { signalingAddress } = conf;
   const iceServers = conf.iceServers ?? [];
 


### PR DESCRIPTION
`createRobotClient` uses the `host` for both the [service host](https://github.com/viamrobotics/viam-typescript-sdk/blob/main/src/robot/dial.ts#L97) and the [WebRTC `host`](https://github.com/viamrobotics/viam-typescript-sdk/blob/main/src/robot/dial.ts#L104). In the case of a machine running with a local config (not using the cloud config), these values can be different. By providing a way to override the service host, `createRobotClient` can connect to machines running with a local config.

This is not a breaking change because existing WebRTC configs will not have `serviceHost` specified.

This was tested by using the Vanilla example with the following config:

```
    machine = await VIAM.createRobotClient({
      serviceHost: "http://localhost:8080",
      host: "localhost:8080", // or the FQDN specified in config.nework.fqdn
      signalingAddress: '',
    });
```