### PR TITLE
APP-7392: Add getVersion to robot client

### DIFF
--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -725,6 +725,12 @@ export class RobotClient extends EventDispatcher implements Robot {
     return this.robotService.getMachineStatus({});
   }
 
+  // VERSION INFO
+
+  async getVersion() {
+    return this.robotService.getVersion({});
+  }
+
   // MODULES
 
   async restartModule(moduleId?: string, moduleName?: string) {

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -173,4 +173,12 @@ export interface Robot {
    * @alpha
    */
   restartModule(moduleId?: string, moduleName?: string): Promise<void>;
+
+  /**
+   * Get version information about the robot, such as platform, version, and api
+   * version.
+   *
+   * @alpha
+   */
+  getVersion(): Promise<proto.GetVersionResponse>;
 }


### PR DESCRIPTION
I need `getVersion` so that I can report RDK version to Sentry for control tab errors. This adds the RPC to the robot client as passthrough.

Let me know what you think - I can also just call `machine.robotService.getVersion({})` directly, so happy to close this PR.