### PR TITLE
APP-7497: Add Button interface and client

### DIFF
--- a/src/components/button.ts
+++ b/src/components/button.ts
@@ -1,0 +1,2 @@
+export type { Button } from './button/button';
+export { ButtonClient } from './button/client';

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -1,0 +1,8 @@
+import type { Struct } from '@bufbuild/protobuf';
+import type { Resource } from '../../types';
+
+/** Represents a physical button. */
+export interface Button extends Resource {
+  /** Press the button. */
+  press: (extra?: Struct) => Promise<void>;
+} 

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -5,4 +5,4 @@ import type { Resource } from '../../types';
 export interface Button extends Resource {
   /** Press the button. */
   press: (extra?: Struct) => Promise<void>;
-} 
+}

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -3,6 +3,6 @@ import type { Resource } from '../../types';
 
 /** Represents a physical button. */
 export interface Button extends Resource {
-  /** Press the button. */
-  press: (extra?: Struct) => Promise<void>;
+  /** Push the button. */
+  push: (extra?: Struct) => Promise<void>;
 }

--- a/src/components/button/client.ts
+++ b/src/components/button/client.ts
@@ -1,9 +1,7 @@
 import { Struct, type JsonValue } from '@bufbuild/protobuf';
 import type { CallOptions, PromiseClient } from '@connectrpc/connect';
 import { ButtonService } from '../../gen/component/button/v1/button_connect';
-import {
-  PushRequest,
-} from '../../gen/component/button/v1/button_pb';
+import { PushRequest } from '../../gen/component/button/v1/button_pb';
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { doCommandFromClient } from '../../utils';
@@ -49,4 +47,4 @@ export class ButtonClient implements Button {
       callOptions
     );
   }
-} 
+}

--- a/src/components/button/client.ts
+++ b/src/components/button/client.ts
@@ -1,0 +1,52 @@
+import { Struct, type JsonValue } from '@bufbuild/protobuf';
+import type { CallOptions, PromiseClient } from '@connectrpc/connect';
+import { ButtonService } from '../../gen/component/button/v1/button_connect';
+import {
+  PushRequest,
+} from '../../gen/component/button/v1/button_pb';
+import type { RobotClient } from '../../robot';
+import type { Options } from '../../types';
+import { doCommandFromClient } from '../../utils';
+import type { Button } from './button';
+
+/**
+ * A gRPC-web client for the Button component.
+ *
+ * @group Clients
+ */
+export class ButtonClient implements Button {
+  private client: PromiseClient<typeof ButtonService>;
+  private readonly name: string;
+  private readonly options: Options;
+  public callOptions: CallOptions = { headers: {} as Record<string, string> };
+
+  constructor(client: RobotClient, name: string, options: Options = {}) {
+    this.client = client.createServiceClient(ButtonService);
+    this.name = name;
+    this.options = options;
+  }
+
+  async press(extra = {}, callOptions = this.callOptions) {
+    const request = new PushRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    this.options.requestLogger?.(request);
+
+    await this.client.push(request, callOptions);
+  }
+
+  async doCommand(
+    command: Struct,
+    callOptions = this.callOptions
+  ): Promise<JsonValue> {
+    return doCommandFromClient(
+      this.client.doCommand,
+      this.name,
+      command,
+      this.options,
+      callOptions
+    );
+  }
+} 

--- a/src/components/button/client.ts
+++ b/src/components/button/client.ts
@@ -24,7 +24,7 @@ export class ButtonClient implements Button {
     this.options = options;
   }
 
-  async press(extra = {}, callOptions = this.callOptions) {
+  async push(extra = {}, callOptions = this.callOptions) {
     const request = new PushRequest({
       name: this.name,
       extra: Struct.fromJson(extra),

--- a/src/main.ts
+++ b/src/main.ts
@@ -152,6 +152,18 @@ export {
 } from './components/board';
 export * as boardApi from './gen/component/board/v1/board_pb';
 
+export { ButtonClient, type Button } from './components/button';
+/**
+ * Raw Protobuf interfaces for a Button component.
+ *
+ * Generated with https://github.com/connectrpc/connect-es
+ *
+ * @deprecated Use {@link ButtonClient} instead.
+ * @alpha
+ * @group Raw Protobufs
+ */
+export * as buttonApi from './gen/component/button/v1/button_pb';
+
 /**
  * Raw Protobuf interfaces for a Camera component.
  *


### PR DESCRIPTION
This adds the new Button API type to the TypeScript SDK using the following API: https://github.com/viamrobotics/api/blob/main/proto/viam/component/button/v1/button.proto

This will get used in the new control cards to render a button card and call the Push API.

## Change log

- Bump API version
- Add Button interface
- Add ButtonClient implementation
- Export Button, ButtonClient, and protos from the package