### PR TITLE
APP-7497: Add Switch interface and client

### DIFF
--- a/src/components/switch.ts
+++ b/src/components/switch.ts
@@ -1,0 +1,2 @@
+export type { Switch } from './switch/switch';
+export { SwitchClient } from './switch/client'; 

--- a/src/components/switch.ts
+++ b/src/components/switch.ts
@@ -1,2 +1,2 @@
 export type { Switch } from './switch/switch';
-export { SwitchClient } from './switch/client'; 
+export { SwitchClient } from './switch/client';

--- a/src/components/switch/client.ts
+++ b/src/components/switch/client.ts
@@ -28,7 +28,11 @@ export class SwitchClient implements Switch {
     this.options = options;
   }
 
-  async setPosition(position: number, extra = {}, callOptions = this.callOptions) {
+  async setPosition(
+    position: number,
+    extra = {},
+    callOptions = this.callOptions
+  ) {
     const request = new SetPositionRequest({
       name: this.name,
       position,
@@ -76,4 +80,4 @@ export class SwitchClient implements Switch {
       callOptions
     );
   }
-} 
+}

--- a/src/components/switch/client.ts
+++ b/src/components/switch/client.ts
@@ -1,0 +1,79 @@
+import { Struct, type JsonValue } from '@bufbuild/protobuf';
+import type { CallOptions, PromiseClient } from '@connectrpc/connect';
+import { SwitchService } from '../../gen/component/switch/v1/switch_connect';
+import {
+  SetPositionRequest,
+  GetPositionRequest,
+  GetNumberOfPositionsRequest,
+} from '../../gen/component/switch/v1/switch_pb';
+import type { RobotClient } from '../../robot';
+import type { Options } from '../../types';
+import { doCommandFromClient } from '../../utils';
+import type { Switch } from './switch';
+
+/**
+ * A gRPC-web client for the Switch component.
+ *
+ * @group Clients
+ */
+export class SwitchClient implements Switch {
+  private client: PromiseClient<typeof SwitchService>;
+  private readonly name: string;
+  private readonly options: Options;
+  public callOptions: CallOptions = { headers: {} as Record<string, string> };
+
+  constructor(client: RobotClient, name: string, options: Options = {}) {
+    this.client = client.createServiceClient(SwitchService);
+    this.name = name;
+    this.options = options;
+  }
+
+  async setPosition(position: number, extra = {}, callOptions = this.callOptions) {
+    const request = new SetPositionRequest({
+      name: this.name,
+      position,
+      extra: Struct.fromJson(extra),
+    });
+
+    this.options.requestLogger?.(request);
+
+    await this.client.setPosition(request, callOptions);
+  }
+
+  async getPosition(extra = {}, callOptions = this.callOptions) {
+    const request = new GetPositionRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    this.options.requestLogger?.(request);
+
+    const resp = await this.client.getPosition(request, callOptions);
+    return resp.position;
+  }
+
+  async getNumberOfPositions(extra = {}, callOptions = this.callOptions) {
+    const request = new GetNumberOfPositionsRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    this.options.requestLogger?.(request);
+
+    const resp = await this.client.getNumberOfPositions(request, callOptions);
+    return resp.numberOfPositions;
+  }
+
+  async doCommand(
+    command: Struct,
+    callOptions = this.callOptions
+  ): Promise<JsonValue> {
+    return doCommandFromClient(
+      this.client.doCommand,
+      this.name,
+      command,
+      this.options,
+      callOptions
+    );
+  }
+} 

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -1,0 +1,14 @@
+import type { Struct } from '@bufbuild/protobuf';
+import type { Resource } from '../../types';
+
+/** Represents a physical switch with multiple positions. */
+export interface Switch extends Resource {
+  /** Set the switch to a specific position. */
+  setPosition: (position: number, extra?: Struct) => Promise<void>;
+
+  /** Get the current position of the switch. */
+  getPosition: (extra?: Struct) => Promise<number>;
+
+  /** Get the total number of positions available on the switch. */
+  getNumberOfPositions: (extra?: Struct) => Promise<number>;
+} 

--- a/src/components/switch/switch.ts
+++ b/src/components/switch/switch.ts
@@ -11,4 +11,4 @@ export interface Switch extends Resource {
 
   /** Get the total number of positions available on the switch. */
   getNumberOfPositions: (extra?: Struct) => Promise<number>;
-} 
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,6 +281,18 @@ export * as sensorApi from './gen/component/sensor/v1/sensor_connect';
 export { StreamClient, type Stream } from './extra/stream';
 export * as streamApi from './gen/stream/v1/stream_pb';
 
+export { SwitchClient, type Switch } from './components/switch';
+/**
+ * Raw Protobuf interfaces for a Switch component.
+ *
+ * Generated with https://github.com/connectrpc/connect-es
+ *
+ * @deprecated Use {@link SwitchClient} instead.
+ * @alpha
+ * @group Raw Protobufs
+ */
+export * as switchApi from './gen/component/switch/v1/switch_pb';
+
 /**
  * Raw Protobuf interfaces for a Generic component.
  *


### PR DESCRIPTION
This adds the new Switch API type to the TypeScript SDK using the following API: https://github.com/viamrobotics/api/blob/main/proto/viam/component/switch/v1/switch.proto

This will get used in the new control cards to render a switch card and call the various APIs.

## Change log

- Add Switch interface
- Add SwitchClient implementation
- Export Switch, SwitchClient, and protos from the package