### PR TITLE
RSDK-9621: Add exports for discovery service

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -164,6 +164,18 @@ export * as boardApi from './gen/component/board/v1/board_pb';
 export { CameraClient, type Camera, type MimeType } from './components/camera';
 export * as cameraApi from './gen/component/camera/v1/camera_pb';
 
+export { DiscoveryClient, type Discovery } from './services/discovery';
+/**
+ * Raw Protobuf interfaces for a Discovery service.
+ *
+ * Generated with https://github.com/connectrpc/connect-es
+ *
+ * @deprecated Use {@link DiscoveryService} instead.
+ * @alpha
+ * @group Raw Protobufs
+ */
+export * as discoveryApi from './gen/service/discovery/v1/discovery_pb';
+
 /**
  * Raw Protobuf interfaces for an Encoder component.
  *


### PR DESCRIPTION
The discovery service was added to TypeScript in https://github.com/viamrobotics/viam-typescript-sdk/pull/436 but did not export the newly added client.

I'm hoping to expedite this PR and do a release ASAP as I'm trying to wrap things up before my last day on Friday. Thank you in advance and sorry for the rush!