### PR TITLE
RSDK-9621: Add export for app robot APIs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ export * as dataApi from './gen/app/data/v1/data_pb';
  */
 export { type AppClient } from './app/app-client';
 export * as appApi from './gen/app/v1/app_pb';
+export * as appRobotApi from './gen/app/v1/robot_pb';
 
 /**
  * Raw Protobuf interfaces for ML Training.


### PR DESCRIPTION
I'm looking for the `appRobotApi.ComponentConfig` type which is the return type of `DiscoveryService.DiscoverResources`.

Proto found here: https://github.com/viamrobotics/api/blob/bdf523364a77f1a6ee559303fcff2cc02a1006e2/proto/viam/app/v1/robot.proto#L89