### PR TITLE
Add getGeometries calls to components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@connectrpc/connect": "^1.6.0",
         "@connectrpc/connect-web": "^1.6.0",
         "bsonfy": "^1.0.2",
-        "exponential-backoff": "^3.1.1"
+        "exponential-backoff": "^3.1.2"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.15.0-1",

--- a/src/components/arm/arm.ts
+++ b/src/components/arm/arm.ts
@@ -2,6 +2,7 @@ import type { PlainMessage, Struct } from '@bufbuild/protobuf';
 import type { Pose, Resource } from '../../types';
 
 import * as armApi from '../../gen/component/arm/v1/arm_pb';
+import type { Geometry } from '../../gen/common/v1/common_pb';
 
 export type ArmJointPositions = PlainMessage<armApi.JointPositions>;
 
@@ -11,6 +12,9 @@ export const { JointPositions: ArmJointPositions } = armApi;
 export interface Arm extends Resource {
   /** Get the position of the end of the arm expressed as a pose */
   getEndPosition: (extra?: Struct) => Promise<Pose>;
+
+  /** Get the geometries of the component in their current configuration */
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
 
   /**
    * Move the end of the arm to the pose.

--- a/src/components/arm/client.ts
+++ b/src/components/arm/client.ts
@@ -14,6 +14,7 @@ import type { RobotClient } from '../../robot';
 import type { Options, Pose } from '../../types';
 import { doCommandFromClient } from '../../utils';
 import type { Arm } from './arm';
+import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
 
 /**
  * A gRPC-web client for the Arm component.
@@ -46,6 +47,16 @@ export class ArmClient implements Arm {
       throw new Error('no pose');
     }
     return result;
+  }
+
+  async getGeometries(extra = {}, callOptions = this.callOptions) {
+    const request = new GetGeometriesRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    const response = await this.client.getGeometries(request, callOptions);
+    return response.geometries;
   }
 
   async moveToPosition(pose: Pose, extra = {}, callOptions = this.callOptions) {

--- a/src/components/base/base.ts
+++ b/src/components/base/base.ts
@@ -1,13 +1,18 @@
 import type { Resource, Struct, Vector3 } from '../../types';
 
 import * as baseApi from '../../gen/component/base/v1/base_pb';
+import type { Geometry } from '../../gen/common/v1/common_pb';
 
 export type BaseProperties = baseApi.GetPropertiesResponse;
 
 export const { GetPropertiesResponse: BaseProperties } = baseApi;
 
 /** Represents a physical base of a robot. */
+
 export interface Base extends Resource {
+  /** Get the geometries of the component in their current configuration */
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
+
   /**
    * Move a base in a straight line by a given distance at a given speed. This
    * method blocks until completed or cancelled.

--- a/src/components/base/client.ts
+++ b/src/components/base/client.ts
@@ -14,6 +14,7 @@ import type { RobotClient } from '../../robot';
 import type { Options, Vector3 } from '../../types';
 import { doCommandFromClient } from '../../utils';
 import type { Base } from './base';
+import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
 
 /**
  * A gRPC-web client for the Base component.
@@ -30,6 +31,16 @@ export class BaseClient implements Base {
     this.client = client.createServiceClient(BaseService);
     this.name = name;
     this.options = options;
+  }
+
+  async getGeometries(extra = {}, callOptions = this.callOptions) {
+    const request = new GetGeometriesRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    const response = await this.client.getGeometries(request, callOptions);
+    return response.geometries;
   }
 
   async moveStraight(

--- a/src/components/camera/camera.ts
+++ b/src/components/camera/camera.ts
@@ -4,6 +4,7 @@ import type {
   IntrinsicParameters,
 } from '../../gen/component/camera/v1/camera_pb';
 import type { Resource } from '../../types';
+import type { Geometry } from '../../gen/common/v1/common_pb';
 
 export interface Properties {
   /** Whether the camera supports the return of point cloud data. */
@@ -26,6 +27,9 @@ export type MimeType =
 
 /** Represents any physical hardware that can capture frames. */
 export interface Camera extends Resource {
+  /** Get the geometries of the component in their current configuration */
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
+
   /**
    * Return a frame from a camera.
    *

--- a/src/components/camera/client.ts
+++ b/src/components/camera/client.ts
@@ -11,6 +11,7 @@ import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { doCommandFromClient } from '../../utils';
 import type { Camera, MimeType } from './camera';
+import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
 
 const PointCloudPCD: MimeType = 'pointcloud/pcd';
 
@@ -29,6 +30,16 @@ export class CameraClient implements Camera {
     this.client = client.createServiceClient(CameraService);
     this.name = name;
     this.options = options;
+  }
+
+  async getGeometries(extra = {}, callOptions = this.callOptions) {
+    const request = new GetGeometriesRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    const response = await this.client.getGeometries(request, callOptions);
+    return response.geometries;
   }
 
   async getImage(

--- a/src/components/gantry/client.ts
+++ b/src/components/gantry/client.ts
@@ -13,6 +13,7 @@ import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { doCommandFromClient } from '../../utils';
 import type { Gantry } from './gantry';
+import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
 
 /**
  * A gRPC-web client for the Gantry component.
@@ -29,6 +30,16 @@ export class GantryClient implements Gantry {
     this.client = client.createServiceClient(GantryService);
     this.name = name;
     this.options = options;
+  }
+
+  async getGeometries(extra = {}, callOptions = this.callOptions) {
+    const request = new GetGeometriesRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    const response = await this.client.getGeometries(request, callOptions);
+    return response.geometries;
   }
 
   async getPosition(extra = {}, callOptions = this.callOptions) {

--- a/src/components/gantry/gantry.ts
+++ b/src/components/gantry/gantry.ts
@@ -1,8 +1,12 @@
 import type { Struct } from '@bufbuild/protobuf';
 import type { Resource } from '../../types';
+import type { Geometry } from '../../gen/common/v1/common_pb';
 
 /** Represents a physical gantry that exists in three-dimensional space. */
 export interface Gantry extends Resource {
+  /** Get the geometries of the component in their current configuration */
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
+
   /**
    * Move each axis of the gantry to the positionsMm at the speeds in
    * speedsMmPerSec

--- a/src/components/generic/client.ts
+++ b/src/components/generic/client.ts
@@ -1,10 +1,11 @@
-import type { JsonValue, Struct } from '@bufbuild/protobuf';
+import { type JsonValue, Struct } from '@bufbuild/protobuf';
 import type { CallOptions, PromiseClient } from '@connectrpc/connect';
 import { GenericService } from '../../gen/component/generic/v1/generic_connect';
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { doCommandFromClient } from '../../utils';
 import type { Generic } from './generic';
+import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
 
 /**
  * A gRPC-web client for the Generic component.
@@ -21,6 +22,16 @@ export class GenericClient implements Generic {
     this.client = client.createServiceClient(GenericService);
     this.name = name;
     this.options = options;
+  }
+
+  async getGeometries(extra = {}, callOptions = this.callOptions) {
+    const request = new GetGeometriesRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    const response = await this.client.getGeometries(request, callOptions);
+    return response.geometries;
   }
 
   async doCommand(

--- a/src/components/generic/generic.ts
+++ b/src/components/generic/generic.ts
@@ -5,4 +5,4 @@ import type { Struct, Resource } from '../../types';
 export interface Generic extends Resource {
   /** Get the geometries of the component in their current configuration */
   getGeometries: (extra?: Struct) => Promise<Geometry[]>;
-} // eslint-disable-line @typescript-eslint/no-empty-interface
+}

--- a/src/components/generic/generic.ts
+++ b/src/components/generic/generic.ts
@@ -1,4 +1,8 @@
-import type { Resource } from '../../types';
+import type { Geometry } from '../../gen/common/v1/common_pb';
+import type { Struct, Resource } from '../../types';
 
 /** Represents a generic component. */
-export interface Generic extends Resource {} // eslint-disable-line @typescript-eslint/no-empty-interface
+export interface Generic extends Resource {
+  /** Get the geometries of the component in their current configuration */
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
+} // eslint-disable-line @typescript-eslint/no-empty-interface

--- a/src/components/gripper/client.ts
+++ b/src/components/gripper/client.ts
@@ -11,6 +11,7 @@ import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { doCommandFromClient } from '../../utils';
 import type { Gripper } from './gripper';
+import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
 
 /**
  * A gRPC-web client for the Gripper component.
@@ -27,6 +28,16 @@ export class GripperClient implements Gripper {
     this.client = client.createServiceClient(GripperService);
     this.name = name;
     this.options = options;
+  }
+
+  async getGeometries(extra = {}, callOptions = this.callOptions) {
+    const request = new GetGeometriesRequest({
+      name: this.name,
+      extra: Struct.fromJson(extra),
+    });
+
+    const response = await this.client.getGeometries(request, callOptions);
+    return response.geometries;
   }
 
   async open(extra = {}, callOptions = this.callOptions) {

--- a/src/components/gripper/gripper.ts
+++ b/src/components/gripper/gripper.ts
@@ -1,8 +1,12 @@
 import type { Struct } from '@bufbuild/protobuf';
 import type { Resource } from '../../types';
+import type { Geometry } from '../../gen/common/v1/common_pb';
 
 /** Represents a physical robotic gripper. */
 export interface Gripper extends Resource {
+  /** Get the geometries of the component in their current configuration */
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
+
   /** Open a gripper of the underlying robot. */
   open: (extra?: Struct) => Promise<void>;
 


### PR DESCRIPTION
### Overview

Adds `getGeometries` methods for all potentially relevant components. Needed for motion planning visualization.

### Questions

Is there anything I need to add to ship an RC to NPM to use this immediately?