### PR TITLE
Make client name field public

### DIFF
--- a/src/components/arm/client.ts
+++ b/src/components/arm/client.ts
@@ -22,7 +22,7 @@ import type { Arm } from './arm';
  */
 export class ArmClient implements Arm {
   private client: PromiseClient<typeof ArmService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/base/client.ts
+++ b/src/components/base/client.ts
@@ -22,7 +22,7 @@ import type { Base } from './base';
  */
 export class BaseClient implements Base {
   private client: PromiseClient<typeof BaseService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/board/client.ts
+++ b/src/components/board/client.ts
@@ -27,7 +27,7 @@ import { type Board, type PowerMode, type Tick } from './board';
  */
 export class BoardClient implements Board {
   private client: PromiseClient<typeof BoardService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/button/client.ts
+++ b/src/components/button/client.ts
@@ -14,7 +14,7 @@ import type { Button } from './button';
  */
 export class ButtonClient implements Button {
   private client: PromiseClient<typeof ButtonService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/camera/client.ts
+++ b/src/components/camera/client.ts
@@ -21,7 +21,7 @@ const PointCloudPCD: MimeType = 'pointcloud/pcd';
  */
 export class CameraClient implements Camera {
   private client: PromiseClient<typeof CameraService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/encoder/client.ts
+++ b/src/components/encoder/client.ts
@@ -18,7 +18,7 @@ import { EncoderPositionType, type Encoder } from './encoder';
  */
 export class EncoderClient implements Encoder {
   private client: PromiseClient<typeof EncoderService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/gantry/client.ts
+++ b/src/components/gantry/client.ts
@@ -21,7 +21,7 @@ import type { Gantry } from './gantry';
  */
 export class GantryClient implements Gantry {
   private client: PromiseClient<typeof GantryService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/generic/client.ts
+++ b/src/components/generic/client.ts
@@ -13,7 +13,7 @@ import type { Generic } from './generic';
  */
 export class GenericClient implements Generic {
   private client: PromiseClient<typeof GenericService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/gripper/client.ts
+++ b/src/components/gripper/client.ts
@@ -19,7 +19,7 @@ import type { Gripper } from './gripper';
  */
 export class GripperClient implements Gripper {
   private client: PromiseClient<typeof GripperService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/input-controller/client.ts
+++ b/src/components/input-controller/client.ts
@@ -18,7 +18,7 @@ import type { InputController, InputControllerEvent } from './input-controller';
  */
 export class InputControllerClient implements InputController {
   private client: PromiseClient<typeof InputControllerService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/motor/client.ts
+++ b/src/components/motor/client.ts
@@ -25,7 +25,7 @@ import type { Motor } from './motor';
  */
 export class MotorClient implements Motor {
   private client: PromiseClient<typeof MotorService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/movement-sensor/client.ts
+++ b/src/components/movement-sensor/client.ts
@@ -24,7 +24,7 @@ import type { MovementSensor } from './movement-sensor';
  */
 export class MovementSensorClient implements MovementSensor {
   private client: PromiseClient<typeof MovementSensorService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/power-sensor/client.ts
+++ b/src/components/power-sensor/client.ts
@@ -20,7 +20,7 @@ import type { PowerSensor } from './power-sensor';
 
 export class PowerSensorClient implements PowerSensor {
   private client: PromiseClient<typeof PowerSensorService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/sensor/client.ts
+++ b/src/components/sensor/client.ts
@@ -15,7 +15,7 @@ import type { Sensor } from './sensor';
  */
 export class SensorClient implements Sensor {
   private client: PromiseClient<typeof SensorService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/servo/client.ts
+++ b/src/components/servo/client.ts
@@ -19,7 +19,7 @@ import type { Servo } from './servo';
  */
 export class ServoClient implements Servo {
   private client: PromiseClient<typeof ServoService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/components/switch/client.ts
+++ b/src/components/switch/client.ts
@@ -18,7 +18,7 @@ import type { Switch } from './switch';
  */
 export class SwitchClient implements Switch {
   private client: PromiseClient<typeof SwitchService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/services/data-manager/client.ts
+++ b/src/services/data-manager/client.ts
@@ -9,7 +9,7 @@ import type { DataManager } from './data-manager';
 
 export class DataManagerClient implements DataManager {
   private client: PromiseClient<typeof DataManagerService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/services/discovery/client.ts
+++ b/src/services/discovery/client.ts
@@ -14,7 +14,7 @@ import type { Discovery } from './discovery';
  */
 export class DiscoveryClient implements Discovery {
   private client: PromiseClient<typeof DiscoveryService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/services/generic/client.ts
+++ b/src/services/generic/client.ts
@@ -13,7 +13,7 @@ import type { Generic } from './generic';
  */
 export class GenericClient implements Generic {
   private client: PromiseClient<typeof GenericService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/services/motion/client.ts
+++ b/src/services/motion/client.ts
@@ -33,7 +33,7 @@ import { type Constraints, type MotionConfiguration } from './types';
  */
 export class MotionClient implements Motion {
   private client: PromiseClient<typeof MotionService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/services/navigation/client.ts
+++ b/src/services/navigation/client.ts
@@ -26,7 +26,7 @@ import type { Mode } from './types';
  */
 export class NavigationClient implements Navigation {
   private client: PromiseClient<typeof NavigationService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/services/slam/client.ts
+++ b/src/services/slam/client.ts
@@ -19,7 +19,7 @@ import type { Slam } from './slam';
  */
 export class SlamClient implements Slam {
   private client: PromiseClient<typeof SLAMService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/services/vision/client.ts
+++ b/src/services/vision/client.ts
@@ -24,7 +24,7 @@ import type { Vision } from './vision';
  */
 export class VisionClient implements Vision {
   private client: PromiseClient<typeof VisionService>;
-  private readonly name: string;
+  public readonly name: string;
   private readonly options: Options;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,9 @@ export interface Options {
 }
 
 export interface Resource {
+  /** The name of the resource. */
+  readonly name: string;
+
   /**
    * Send/Receive arbitrary commands to the resource.
    *


### PR DESCRIPTION
### Overview

It's often useful to read the corresponding resource name from a client, for example when executing requests on the `robotClient` in a scope where only a resource client and not the original resource name is available. In this PR I've switched all names to public but kept the readonly modifier.