### PR TITLE
DATA-3861 Update TS SDK to use new binary data id fields

### DIFF
--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -17,7 +17,6 @@ import {
   BinaryDataByFilterResponse,
   BinaryDataByIDsRequest,
   BinaryDataByIDsResponse,
-  BinaryID,
   BoundingBoxLabelsByFilterRequest,
   BoundingBoxLabelsByFilterResponse,
   CaptureInterval,

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -93,17 +93,8 @@ describe('DataClient tests', () => {
   const includeInternalData = false;
   const startDate = new Date(1, 1, 1, 1, 1, 1);
 
-  const binaryId1 = new BinaryID({
-    fileId: 'testFileId1',
-    organizationId: 'testOrgId',
-    locationId: 'testLocationId',
-  });
-  const binaryId2 = new BinaryID({
-    fileId: 'testFileId1',
-    organizationId: 'testOrgId',
-    locationId: 'testLocationId',
-  });
-
+  const binaryId1 = 'testID1';
+  const binaryId2 = 'testID2';
   describe('exportTabularData tests', () => {
     const sharedAttributes = {
       partId: 'partId1',
@@ -426,7 +417,7 @@ describe('DataClient tests', () => {
 
     it('get binary data by id', async () => {
       const expectedRequest = new BinaryDataByIDsRequest({
-        binaryIds: [binaryId1],
+        binaryDataIds: [binaryId1],
         includeBinary: true,
       });
 
@@ -515,7 +506,7 @@ describe('DataClient tests', () => {
         service(DataService, {
           deleteBinaryDataByIDs: (req) => {
             return new DeleteBinaryDataByIDsResponse({
-              deletedCount: BigInt(req.binaryIds.length),
+              deletedCount: BigInt(req.binaryDataIds.length),
             });
           },
         });
@@ -549,7 +540,7 @@ describe('DataClient tests', () => {
 
     it('add tags to binary data', async () => {
       const expectedRequest = new AddTagsToBinaryDataByIDsRequest({
-        binaryIds: [binaryId1, binaryId2],
+        binaryDataIds: [binaryId1, binaryId2],
         tags: ['tag1', 'tag2'],
       });
 
@@ -602,7 +593,7 @@ describe('DataClient tests', () => {
 
     it('remove tags to binary data', async () => {
       const expectedRequest = new RemoveTagsFromBinaryDataByIDsRequest({
-        binaryIds: [binaryId1, binaryId2],
+        binaryDataIds: [binaryId1, binaryId2],
         tags: ['tag1', 'tag2'],
       });
 
@@ -688,7 +679,7 @@ describe('DataClient tests', () => {
 
     it('add bounding box to image', async () => {
       const expectedRequest = new AddBoundingBoxToImageByIDRequest({
-        binaryId: binaryId1,
+        binaryDataId: binaryId1,
         label: 'label',
         xMinNormalized: 0,
         yMinNormalized: 0,
@@ -724,7 +715,7 @@ describe('DataClient tests', () => {
 
     it('remove bounding box from image', async () => {
       const expectedRequest = new RemoveBoundingBoxFromImageByIDRequest({
-        binaryId: binaryId1,
+        binaryDataId: binaryId1,
         bboxId: 'bboxId',
       });
 
@@ -824,7 +815,7 @@ describe('DataClient tests', () => {
 
     it('add binary data to dataset', async () => {
       const expectedRequest = new AddBinaryDataToDatasetByIDsRequest({
-        binaryIds: [binaryId1, binaryId2],
+        binaryDataIds: [binaryId1, binaryId2],
         datasetId: 'datasetId',
       });
 
@@ -851,7 +842,7 @@ describe('DataClient tests', () => {
 
     it('remove binary data from dataset', async () => {
       const expectedRequest = new RemoveBinaryDataFromDatasetByIDsRequest({
-        binaryIds: [binaryId1, binaryId2],
+        binaryDataIds: [binaryId1, binaryId2],
         datasetId: 'datasetId',
       });
 
@@ -1249,7 +1240,7 @@ describe('DataSyncClient tests', () => {
           dataCaptureUpload: (req) => {
             capReq = req;
             return new DataCaptureUploadResponse({
-              fileId: 'fileId',
+              binaryDataId: 'fileId',
             });
           },
         });

--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -558,8 +558,8 @@ describe('DataClient tests', () => {
     });
 
     it('delete binary data by ids', async () => {
-      // const promise1 = await subject().deleteBinaryDataByIds([binaryId1]);
-      // expect(promise1).toEqual(1n);
+      const promise1 = await subject().deleteBinaryDataByIds([binaryId1]);
+      expect(promise1).toEqual(1n);
 
       const promise2 = await subject().deleteBinaryDataByIds([
         binaryId1,

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -58,6 +58,13 @@ export type Dataset = Partial<PBDataset> & {
   created?: Date;
 };
 
+const logDeprecationWarning = () => {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'The BinaryID type is deprecated and will be removed in a future release. Please migrate to the BinaryDataId field instead.'
+  );
+};
+
 export class DataClient {
   private dataClient: PromiseClient<typeof DataService>;
   private datasetClient: PromiseClient<typeof DatasetService>;
@@ -311,6 +318,7 @@ export class DataClient {
       });
       return resp.data;
     }
+    logDeprecationWarning();
     const resp = await this.dataClient.binaryDataByIDs({
       binaryIds: ids as BinaryID[],
       includeBinary: true,
@@ -366,6 +374,7 @@ export class DataClient {
       });
       return resp.deletedCount;
     }
+    logDeprecationWarning();
     const resp = await this.dataClient.deleteBinaryDataByIDs({
       binaryIds: ids as BinaryID[],
     });
@@ -380,15 +389,18 @@ export class DataClient {
    * @param ids The IDs of the data to be tagged. Must be non-empty.
    */
   async addTagsToBinaryDataByIds(tags: string[], ids: string[] | BinaryID[]) {
-    await (Array.isArray(ids) && typeof ids[0] === 'string'
-      ? this.dataClient.addTagsToBinaryDataByIDs({
-          tags,
-          binaryDataIds: ids as string[],
-        })
-      : this.dataClient.addTagsToBinaryDataByIDs({
-          tags,
-          binaryIds: ids as BinaryID[],
-        }));
+    if (Array.isArray(ids) && typeof ids[0] === 'string') {
+      await this.dataClient.addTagsToBinaryDataByIDs({
+        tags,
+        binaryDataIds: ids as string[],
+      });
+      return;
+    }
+    logDeprecationWarning();
+    await this.dataClient.addTagsToBinaryDataByIDs({
+      tags,
+      binaryIds: ids as BinaryID[],
+    });
   }
 
   /**
@@ -424,6 +436,7 @@ export class DataClient {
       });
       return resp.deletedCount;
     }
+    logDeprecationWarning();
     const resp = await this.dataClient.removeTagsFromBinaryDataByIDs({
       tags,
       binaryIds: ids as BinaryID[],
@@ -494,6 +507,7 @@ export class DataClient {
       });
       return resp.bboxId;
     }
+    logDeprecationWarning();
     const resp = await this.dataClient.addBoundingBoxToImageByID({
       binaryId,
       label,
@@ -515,15 +529,18 @@ export class DataClient {
     binId: string | BinaryID,
     bboxId: string
   ) {
-    await (typeof binId === 'string'
-      ? this.dataClient.removeBoundingBoxFromImageByID({
-          binaryDataId: binId,
-          bboxId,
-        })
-      : this.dataClient.removeBoundingBoxFromImageByID({
-          binaryId: binId,
-          bboxId,
-        }));
+    if (typeof binId === 'string') {
+      await this.dataClient.removeBoundingBoxFromImageByID({
+        binaryDataId: binId,
+        bboxId,
+      });
+      return;
+    }
+    logDeprecationWarning();
+    await this.dataClient.removeBoundingBoxFromImageByID({
+      binaryId: binId,
+      bboxId,
+    });
   }
 
   /**
@@ -575,15 +592,18 @@ export class DataClient {
     ids: string[] | BinaryID[],
     datasetId: string
   ) {
-    await (Array.isArray(ids) && typeof ids[0] === 'string'
-      ? this.dataClient.addBinaryDataToDatasetByIDs({
-          binaryDataIds: ids as string[],
-          datasetId,
-        })
-      : this.dataClient.addBinaryDataToDatasetByIDs({
-          binaryIds: ids as BinaryID[],
-          datasetId,
-        }));
+    if (Array.isArray(ids) && typeof ids[0] === 'string') {
+      await this.dataClient.addBinaryDataToDatasetByIDs({
+        binaryDataIds: ids as string[],
+        datasetId,
+      });
+      return;
+    }
+    logDeprecationWarning();
+    await this.dataClient.addBinaryDataToDatasetByIDs({
+      binaryIds: ids as BinaryID[],
+      datasetId,
+    });
   }
 
   /**
@@ -596,15 +616,18 @@ export class DataClient {
     ids: string[] | BinaryID[],
     datasetId: string
   ) {
-    await (Array.isArray(ids) && typeof ids[0] === 'string'
-      ? this.dataClient.removeBinaryDataFromDatasetByIDs({
-          binaryDataIds: ids as string[],
-          datasetId,
-        })
-      : this.dataClient.removeBinaryDataFromDatasetByIDs({
-          binaryIds: ids as BinaryID[],
-          datasetId,
-        }));
+    if (Array.isArray(ids) && typeof ids[0] === 'string') {
+      await this.dataClient.removeBinaryDataFromDatasetByIDs({
+        binaryDataIds: ids as string[],
+        datasetId,
+      });
+      return;
+    }
+    logDeprecationWarning();
+    await this.dataClient.removeBinaryDataFromDatasetByIDs({
+      binaryIds: ids as BinaryID[],
+      datasetId,
+    });
   }
 
   /**

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -7,6 +7,7 @@ import {
 } from '@connectrpc/connect';
 import { DataService } from '../gen/app/data/v1/data_connect';
 import {
+  BinaryID,
   CaptureInterval,
   CaptureMetadata,
   Filter,
@@ -302,9 +303,16 @@ export class DataClient {
    * @param ids The IDs of the requested binary data
    * @returns An array of data objects
    */
-  async binaryDataByIds(ids: string[]) {
+  async binaryDataByIds(ids: string[] | BinaryID[]) {
+    if (Array.isArray(ids) && typeof ids[0] === 'string') {
+      const resp = await this.dataClient.binaryDataByIDs({
+        binaryDataIds: ids as string[],
+        includeBinary: true,
+      });
+      return resp.data;
+    }
     const resp = await this.dataClient.binaryDataByIDs({
-      binaryDataIds: ids,
+      binaryIds: ids as BinaryID[],
       includeBinary: true,
     });
     return resp.data;
@@ -351,9 +359,15 @@ export class DataClient {
    * @param ids The IDs of the data to be deleted. Must be non-empty.
    * @returns The number of items deleted
    */
-  async deleteBinaryDataByIds(ids: string[]) {
+  async deleteBinaryDataByIds(ids: string[] | BinaryID[]) {
+    if (Array.isArray(ids) && typeof ids[0] === 'string') {
+      const resp = await this.dataClient.deleteBinaryDataByIDs({
+        binaryDataIds: ids as string[],
+      });
+      return resp.deletedCount;
+    }
     const resp = await this.dataClient.deleteBinaryDataByIDs({
-      binaryDataIds: ids,
+      binaryIds: ids as BinaryID[],
     });
     return resp.deletedCount;
   }
@@ -365,11 +379,16 @@ export class DataClient {
    *   non-empty.
    * @param ids The IDs of the data to be tagged. Must be non-empty.
    */
-  async addTagsToBinaryDataByIds(tags: string[], ids: string[]) {
-    await this.dataClient.addTagsToBinaryDataByIDs({
-      tags,
-      binaryDataIds: ids,
-    });
+  async addTagsToBinaryDataByIds(tags: string[], ids: string[] | BinaryID[]) {
+    await (Array.isArray(ids) && typeof ids[0] === 'string'
+      ? this.dataClient.addTagsToBinaryDataByIDs({
+          tags,
+          binaryDataIds: ids as string[],
+        })
+      : this.dataClient.addTagsToBinaryDataByIDs({
+          tags,
+          binaryIds: ids as BinaryID[],
+        }));
   }
 
   /**
@@ -394,10 +413,20 @@ export class DataClient {
    * @param ids The IDs of the data to be edited. Must be non-empty.
    * @returns The number of items deleted
    */
-  async removeTagsFromBinaryDataByIds(tags: string[], ids: string[]) {
+  async removeTagsFromBinaryDataByIds(
+    tags: string[],
+    ids: string[] | BinaryID[]
+  ) {
+    if (Array.isArray(ids) && typeof ids[0] === 'string') {
+      const resp = await this.dataClient.removeTagsFromBinaryDataByIDs({
+        tags,
+        binaryDataIds: ids as string[],
+      });
+      return resp.deletedCount;
+    }
     const resp = await this.dataClient.removeTagsFromBinaryDataByIDs({
       tags,
-      binaryDataIds: ids,
+      binaryIds: ids as BinaryID[],
     });
     return resp.deletedCount;
   }
@@ -434,7 +463,7 @@ export class DataClient {
   /**
    * Add bounding box to an image.
    *
-   * @param binaryDataId The ID of the image to add the bounding box to
+   * @param binaryId The ID of the image to add the bounding box to
    * @param label A label for the bounding box
    * @param xMinNormalized The min X value of the bounding box normalized from 0
    *   to 1
@@ -447,15 +476,26 @@ export class DataClient {
    * @returns The bounding box ID
    */
   async addBoundingBoxToImageById(
-    binaryDataId: string,
+    binaryId: string | BinaryID,
     label: string,
     xMinNormalized: number,
     yMinNormalized: number,
     xMaxNormalized: number,
     yMaxNormalized: number
   ) {
+    if (typeof binaryId === 'string') {
+      const resp = await this.dataClient.addBoundingBoxToImageByID({
+        binaryDataId: binaryId,
+        label,
+        xMinNormalized,
+        yMinNormalized,
+        xMaxNormalized,
+        yMaxNormalized,
+      });
+      return resp.bboxId;
+    }
     const resp = await this.dataClient.addBoundingBoxToImageByID({
-      binaryDataId,
+      binaryId,
       label,
       xMinNormalized,
       yMinNormalized,
@@ -471,11 +511,19 @@ export class DataClient {
    * @param binId The ID of the image to remove the bounding box from
    * @param bboxId The ID of the bounding box to remove
    */
-  async removeBoundingBoxFromImageById(binId: string, bboxId: string) {
-    await this.dataClient.removeBoundingBoxFromImageByID({
-      binaryDataId: binId,
-      bboxId,
-    });
+  async removeBoundingBoxFromImageById(
+    binId: string | BinaryID,
+    bboxId: string
+  ) {
+    await (typeof binId === 'string'
+      ? this.dataClient.removeBoundingBoxFromImageByID({
+          binaryDataId: binId,
+          bboxId,
+        })
+      : this.dataClient.removeBoundingBoxFromImageByID({
+          binaryId: binId,
+          bboxId,
+        }));
   }
 
   /**
@@ -523,11 +571,19 @@ export class DataClient {
    * @param ids The IDs of binary data to add to dataset
    * @param datasetId The ID of the dataset to be added to
    */
-  async addBinaryDataToDatasetByIds(ids: string[], datasetId: string) {
-    await this.dataClient.addBinaryDataToDatasetByIDs({
-      binaryDataIds: ids,
-      datasetId,
-    });
+  async addBinaryDataToDatasetByIds(
+    ids: string[] | BinaryID[],
+    datasetId: string
+  ) {
+    await (Array.isArray(ids) && typeof ids[0] === 'string'
+      ? this.dataClient.addBinaryDataToDatasetByIDs({
+          binaryDataIds: ids as string[],
+          datasetId,
+        })
+      : this.dataClient.addBinaryDataToDatasetByIDs({
+          binaryIds: ids as BinaryID[],
+          datasetId,
+        }));
   }
 
   /**
@@ -536,11 +592,19 @@ export class DataClient {
    * @param ids The IDs of the binary data to remove from dataset
    * @param datasetId The ID of the dataset to be removed from
    */
-  async removeBinaryDataFromDatasetByIds(ids: string[], datasetId: string) {
-    await this.dataClient.removeBinaryDataFromDatasetByIDs({
-      binaryDataIds: ids,
-      datasetId,
-    });
+  async removeBinaryDataFromDatasetByIds(
+    ids: string[] | BinaryID[],
+    datasetId: string
+  ) {
+    await (Array.isArray(ids) && typeof ids[0] === 'string'
+      ? this.dataClient.removeBinaryDataFromDatasetByIDs({
+          binaryDataIds: ids as string[],
+          datasetId,
+        })
+      : this.dataClient.removeBinaryDataFromDatasetByIDs({
+          binaryIds: ids as BinaryID[],
+          datasetId,
+        }));
   }
 
   /**
@@ -712,7 +776,7 @@ export class DataClient {
    * @param dataRequestTimes Tuple containing `Date` objects denoting the times
    *   this data was requested[0] by the robot and received[1] from the
    *   appropriate sensor.
-   * @returns The file ID of the uploaded data
+   * @returns The binary data ID of the uploaded data
    */
   async binaryDataCaptureUpload(
     binaryData: Uint8Array,

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -7,7 +7,6 @@ import {
 } from '@connectrpc/connect';
 import { DataService } from '../gen/app/data/v1/data_connect';
 import {
-  BinaryID,
   CaptureInterval,
   CaptureMetadata,
   Filter,
@@ -298,14 +297,14 @@ export class DataClient {
   }
 
   /**
-   * Get binary data using the BinaryID.
+   * Get binary data using the binary data ID.
    *
    * @param ids The IDs of the requested binary data
    * @returns An array of data objects
    */
-  async binaryDataByIds(ids: BinaryID[]) {
+  async binaryDataByIds(ids: string[]) {
     const resp = await this.dataClient.binaryDataByIDs({
-      binaryIds: ids,
+      binaryDataIds: ids,
       includeBinary: true,
     });
     return resp.data;
@@ -352,9 +351,9 @@ export class DataClient {
    * @param ids The IDs of the data to be deleted. Must be non-empty.
    * @returns The number of items deleted
    */
-  async deleteBinaryDataByIds(ids: BinaryID[]) {
+  async deleteBinaryDataByIds(ids: string[]) {
     const resp = await this.dataClient.deleteBinaryDataByIDs({
-      binaryIds: ids,
+      binaryDataIds: ids,
     });
     return resp.deletedCount;
   }
@@ -366,10 +365,10 @@ export class DataClient {
    *   non-empty.
    * @param ids The IDs of the data to be tagged. Must be non-empty.
    */
-  async addTagsToBinaryDataByIds(tags: string[], ids: BinaryID[]) {
+  async addTagsToBinaryDataByIds(tags: string[], ids: string[]) {
     await this.dataClient.addTagsToBinaryDataByIDs({
       tags,
-      binaryIds: ids,
+      binaryDataIds: ids,
     });
   }
 
@@ -395,10 +394,10 @@ export class DataClient {
    * @param ids The IDs of the data to be edited. Must be non-empty.
    * @returns The number of items deleted
    */
-  async removeTagsFromBinaryDataByIds(tags: string[], ids: BinaryID[]) {
+  async removeTagsFromBinaryDataByIds(tags: string[], ids: string[]) {
     const resp = await this.dataClient.removeTagsFromBinaryDataByIDs({
       tags,
-      binaryIds: ids,
+      binaryDataIds: ids,
     });
     return resp.deletedCount;
   }
@@ -435,7 +434,7 @@ export class DataClient {
   /**
    * Add bounding box to an image.
    *
-   * @param binaryId The ID of the image to add the bounding box to
+   * @param binaryDataId The ID of the image to add the bounding box to
    * @param label A label for the bounding box
    * @param xMinNormalized The min X value of the bounding box normalized from 0
    *   to 1
@@ -448,7 +447,7 @@ export class DataClient {
    * @returns The bounding box ID
    */
   async addBoundingBoxToImageById(
-    id: BinaryID,
+    binaryDataId: string,
     label: string,
     xMinNormalized: number,
     yMinNormalized: number,
@@ -456,7 +455,7 @@ export class DataClient {
     yMaxNormalized: number
   ) {
     const resp = await this.dataClient.addBoundingBoxToImageByID({
-      binaryId: id,
+      binaryDataId,
       label,
       xMinNormalized,
       yMinNormalized,
@@ -472,9 +471,9 @@ export class DataClient {
    * @param binId The ID of the image to remove the bounding box from
    * @param bboxId The ID of the bounding box to remove
    */
-  async removeBoundingBoxFromImageById(binId: BinaryID, bboxId: string) {
+  async removeBoundingBoxFromImageById(binId: string, bboxId: string) {
     await this.dataClient.removeBoundingBoxFromImageByID({
-      binaryId: binId,
+      binaryDataId: binId,
       bboxId,
     });
   }
@@ -524,9 +523,9 @@ export class DataClient {
    * @param ids The IDs of binary data to add to dataset
    * @param datasetId The ID of the dataset to be added to
    */
-  async addBinaryDataToDatasetByIds(ids: BinaryID[], datasetId: string) {
+  async addBinaryDataToDatasetByIds(ids: string[], datasetId: string) {
     await this.dataClient.addBinaryDataToDatasetByIDs({
-      binaryIds: ids,
+      binaryDataIds: ids,
       datasetId,
     });
   }
@@ -537,9 +536,9 @@ export class DataClient {
    * @param ids The IDs of the binary data to remove from dataset
    * @param datasetId The ID of the dataset to be removed from
    */
-  async removeBinaryDataFromDatasetByIds(ids: BinaryID[], datasetId: string) {
+  async removeBinaryDataFromDatasetByIds(ids: string[], datasetId: string) {
     await this.dataClient.removeBinaryDataFromDatasetByIDs({
-      binaryIds: ids,
+      binaryDataIds: ids,
       datasetId,
     });
   }
@@ -752,7 +751,7 @@ export class DataClient {
     });
 
     const resp = await this.dataSyncClient.dataCaptureUpload(req);
-    return resp.fileId;
+    return resp.binaryDataId;
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
This PR changes the TS SDK to use the new id field. The change can be [read about more here.](https://docs.google.com/document/d/1zapFPyrkIRNrnD7wyD9XolOVUKFgth2cXQRoX53jifU/edit?usp=sharing) but basically, we're deprecating the BinaryID struct and replacing it with a string. This points all methods to these new fields. 