### PR TITLE
make name public and export types for rendering

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -199,7 +199,13 @@ export { GantryClient, type Gantry } from './components/gantry';
  */
 export * as gantryApi from './gen/component/gantry/v1/gantry_pb';
 
-export { MLModelClient, type MLModel } from './services/ml-model';
+export {
+  MLModelClient,
+  type MLModel,
+  type Metadata,
+  type TensorInfo,
+  type FlatTensors,
+} from './services/ml-model';
 
 export { MotorClient, type Motor } from './components/motor';
 /**

--- a/src/services/ml-model/client.ts
+++ b/src/services/ml-model/client.ts
@@ -10,8 +10,9 @@ import { MLModelService } from '../../gen/service/mlmodel/v1/mlmodel_connect';
 
 export class MLModelClient implements MLModel {
   private client: PromiseClient<typeof MLModelService>;
-  private readonly name: string;
   private readonly options: Options;
+
+  public readonly name: string;
   public callOptions: CallOptions = { headers: {} as Record<string, string> };
 
   constructor(client: RobotClient, name: string, options: Options = {}) {

--- a/src/services/ml-model/index.ts
+++ b/src/services/ml-model/index.ts
@@ -1,2 +1,2 @@
-export type { MLModel, FlatTensors } from './ml-model';
+export type { MLModel, Metadata, FlatTensors, TensorInfo } from './ml-model';
 export { MLModelClient } from './client';

--- a/src/services/ml-model/ml-model.ts
+++ b/src/services/ml-model/ml-model.ts
@@ -1,6 +1,8 @@
 import type { Struct } from '@bufbuild/protobuf';
 import type * as mlModelAPI from '../../gen/service/mlmodel/v1/mlmodel_pb';
 
+export type Metadata = mlModelAPI.Metadata;
+export type TensorInfo = mlModelAPI.TensorInfo;
 export type FlatTensors = mlModelAPI.FlatTensors;
 
 export interface MLModel {


### PR DESCRIPTION
As I was working on the MLModel service test card, I noticed we were having some type issues with the client. First, the `name` field needed to be public. Second, we were missing some type exports that are pretty necessary to render anything from the metadata response. Shouldn't be anything breaking.