### PR TITLE
DOCS-3790: Add motion and SLAM backlinks

### DIFF
--- a/src/services/motion/motion.ts
+++ b/src/services/motion/motion.ts
@@ -57,6 +57,9 @@ export interface Motion extends Resource {
    * const moved = await motion.move(goalPoseInFrame, gripperName);
    * ```
    *
+   * For more information, see [Motion
+   * API](https://docs.viam.com/dev/reference/apis/services/motion/#move).
+   *
    * @param destination - Destination to move to, which can a pose in the
    *   reference frame of any frame in the robot's frame system.
    * @param componentName - Component on the robot to move to the specified
@@ -120,6 +123,9 @@ export interface Motion extends Resource {
    * );
    * ```
    *
+   * For more information, see [Motion
+   * API](https://docs.viam.com/dev/reference/apis/services/motion/#moveonmap).
+   *
    * @param destination - Specify a destination to, which can be any `Pose` with
    *   respect to the SLAM map's origin.
    * @param componentName - Component on the robot to move to the specified
@@ -179,6 +185,9 @@ export interface Motion extends Resource {
    * );
    * ```
    *
+   * For more information, see [Motion
+   * API](https://docs.viam.com/dev/reference/apis/services/motion/#moveonglobe).
+   *
    * @param destination - Destination for the component to move to, represented
    *   as a `GeoPoint`.
    * @param componentName - The name of the component to move.
@@ -221,6 +230,9 @@ export interface Motion extends Resource {
    * await motion.stopPlan(baseName);
    * ```
    *
+   * For more information, see [Motion
+   * API](https://docs.viam.com/dev/reference/apis/services/motion/#stopplan).
+   *
    * @param componentName - The component to stop
    */
   stopPlan: (componentName: ResourceName, extra?: Struct) => Promise<null>;
@@ -253,6 +265,9 @@ export interface Motion extends Resource {
    * // Get the plan(s) of the base component
    * const response = await motion.getPlan(baseName);
    * ```
+   *
+   * For more information, see [Motion
+   * API](https://docs.viam.com/dev/reference/apis/services/motion/#getplan).
    *
    * @param componentName - The component to query
    * @param destinationFrame - The reference frame in which the component's
@@ -287,6 +302,9 @@ export interface Motion extends Resource {
    * const response = await motion.listPlanStatuses();
    * ```
    *
+   * For more information, see [Motion
+   * API](https://docs.viam.com/dev/reference/apis/services/motion/#listplanstatuses).
+   *
    * @param onlyActivePlans - If true, the response will only return plans which
    *   are executing.
    */
@@ -317,6 +335,9 @@ export interface Motion extends Resource {
    *   []
    * );
    * ```
+   *
+   * For more information, see [Motion
+   * API](https://docs.viam.com/dev/reference/apis/services/motion/#getpose).
    *
    * @param componentName - The component whose `Pose` is being requested.
    * @param destinationFrame - The reference frame in which the component's

--- a/src/services/slam/client.ts
+++ b/src/services/slam/client.ts
@@ -39,10 +39,10 @@ export class SlamClient implements Slam {
     return this.client.getPosition(request, callOptions);
   }
 
-  getPointCloudMap = async (
+  async getPointCloudMap(
     returnEditedMap?: boolean,
     callOptions = this.callOptions
-  ): Promise<Uint8Array> => {
+  ): Promise<Uint8Array> {
     const request = new GetPointCloudMapRequest({
       name: this.name,
       returnEditedMap,
@@ -55,11 +55,11 @@ export class SlamClient implements Slam {
       chunks.push(chunk.pointCloudPcdChunk);
     }
     return concatArrayU8(chunks);
-  };
+  }
 
-  getInternalState = async (
+  async getInternalState(
     callOptions = this.callOptions
-  ): Promise<Uint8Array> => {
+  ): Promise<Uint8Array> {
     const request = new GetInternalStateRequest({
       name: this.name,
     });
@@ -71,7 +71,7 @@ export class SlamClient implements Slam {
       chunks.push(chunk.internalStateChunk);
     }
     return concatArrayU8(chunks);
-  };
+  }
 
   async getProperties(callOptions = this.callOptions) {
     const request = new GetPropertiesRequest({

--- a/src/services/slam/slam.ts
+++ b/src/services/slam/slam.ts
@@ -19,6 +19,9 @@ export interface Slam extends Resource {
    * const position = await slam.getPosition();
    * console.log('Current position:', position);
    * ```
+   *
+   * For more information, see [SLAM
+   * API](https://docs.viam.com/dev/reference/apis/services/slam/#getposition).
    */
   getPosition: () => Promise<SlamPosition>;
 
@@ -36,6 +39,9 @@ export interface Slam extends Resource {
    * // Get the edited point cloud map
    * const editedMap = await slam.getPointCloudMap(true);
    * ```
+   *
+   * For more information, see [SLAM
+   * API](https://docs.viam.com/dev/reference/apis/services/slam/#getpointcloudmap).
    */
   getPointCloudMap: (returnEditedMap?: boolean) => Promise<Uint8Array>;
 
@@ -51,6 +57,9 @@ export interface Slam extends Resource {
    * // Get the internal state of the SLAM algorithm
    * const internalState = await slam.getInternalState();
    * ```
+   *
+   * For more information, see [SLAM
+   * API](https://docs.viam.com/dev/reference/apis/services/slam/#getinternalstate).
    */
   getInternalState: () => Promise<Uint8Array>;
 
@@ -66,6 +75,9 @@ export interface Slam extends Resource {
    * const properties = await slam.getProperties();
    * console.log('SLAM properties:', properties);
    * ```
+   *
+   * For more information, see [SLAM
+   * API](https://docs.viam.com/dev/reference/apis/services/slam/#getproperties).
    */
   getProperties: () => Promise<SlamProperties>;
 }


### PR DESCRIPTION
I noticed that the getInternalState and getPointCloudMap examples are not rendering in the [TS docs](https://ts.viam.dev/classes/SlamClient.html), and this seemed to be fixed by changing the arrow functions to regular functions. However I'm not sure whether this creates other problems.