### PR TITLE
Extend TURN servers with tcp variant

### DIFF
--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -448,8 +448,15 @@ const processWebRTCOpts = async (
   );
   const additionalIceServers: RTCIceServer[] = config.additionalIceServers.map(
     (ice) => {
+      const iceUrls = [];
+      for(const iUrl of ice.urls){
+        if (iUrl.endsWith("udp")){
+          iceUrls.push(`${iUrl.slice(0, -3)}tcp`);
+        }
+        iceUrls.push(iUrl);
+      }
       return {
-        urls: ice.urls,
+        urls: iceUrls,
         credential: ice.credential,
         username: ice.username,
       };

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -451,8 +451,8 @@ const processWebRTCOpts = async (
       const iceUrls = [];
       // always extend the list with tcp variants in order to facilitate cases
       // where udp might be blocked
-      for(const iUrl of ice.urls){
-        if (iUrl.endsWith("udp")){
+      for (const iUrl of ice.urls) {
+        if (iUrl.endsWith('udp')) {
           iceUrls.push(`${iUrl.slice(0, -3)}tcp`);
         }
         iceUrls.push(iUrl);

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -449,6 +449,8 @@ const processWebRTCOpts = async (
   const additionalIceServers: RTCIceServer[] = config.additionalIceServers.map(
     (ice) => {
       const iceUrls = [];
+      // always extend the list with tcp variants in order to facilitate cases
+      // where udp might be blocked
       for(const iUrl of ice.urls){
         if (iUrl.endsWith("udp")){
           iceUrls.push(`${iUrl.slice(0, -3)}tcp`);


### PR DESCRIPTION
same functionality as https://github.com/viamrobotics/goutils/pull/425

in some cases where udp traffic is blocked, we can relay traffic through tcp instead, but tcp has to be added manually