### PR TITLE
docs: update doCommand method example code

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,11 @@ export interface Resource {
    * ```ts
    * import { Struct } from '@viamrobotics/sdk';
    *
-   * const result = await resource.doCommand(Struct.fromJson({
-   *   myCommand: { key: 'value' },
-   * }));
+   * const result = await resource.doCommand(
+   *   Struct.fromJson({
+   *     myCommand: { key: 'value' },
+   *   })
+   * );
    * ```
    *
    * @param command - The command to execute.

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,10 +17,11 @@ export interface Resource {
    * @example
    *
    * ```ts
-   * const result = await resource.doCommand({
-   *   name: 'myCommand',
-   *   args: { key: 'value' },
-   * });
+   * import { Struct } from '@viamrobotics/sdk';
+   *
+   * const result = await resource.doCommand(Struct.fromJson({
+   *   myCommand: { key: 'value' },
+   * }));
    * ```
    *
    * @param command - The command to execute.


### PR DESCRIPTION
Reported by a developer from a company using the TypeScript SDK: https://discord.com/channels/1083489952408539288/1366926806237712451/1367524200495058978

The `doCommand` method expects a `Struct` as the command message rather than a plain object. It might be more ergonomic to just wrap any plain object in a Struct, but that's a not something I want to implement without a longer conversation. 
