### PR TITLE
fix branch name in ai-updater workflow

### DIFF
--- a/.github/workflows/ai-updater.yml
+++ b/.github/workflows/ai-updater.yml
@@ -3,14 +3,14 @@ name: AI Updater Workflow
 on:
   push:
     branches:
-      - workflow/update-proto
+      - workflow/update-protos
   workflow_dispatch:
 
 jobs:
   call-ai-updater:
     uses: gabegottlob/viam-ai-updater/.github/workflows/ai-updater.yml@main
     with:
-        target_branch: workflow/update-proto
+        target_branch: workflow/update-protos
         sdk: typescript
     secrets:
         GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}


### PR DESCRIPTION
It turns out the update protos workflow creates a branch called workflow/update-protos (whereas in the Python SDK it is called workflow/update-proto). This PR fixes this inconsistency in the AI Updater.  