### PR TITLE
update default timeout for Dial connections to 10s 

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const DIAL_TIMEOUT = 5000;
+export const DIAL_TIMEOUT = 10_000;


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-9256

# Description
We currently have a connection refresh that retires after 5s which mismatches the 10s "offer deadline" expected. This PR updates the constant to be in line with the expected timeout so that we don't send new call requests pre-maturely.

# Testing
Tested on local by updating this value and ensuring the call network requests do not overlap

https://github.com/user-attachments/assets/86a1b9dc-8691-45c6-8d3b-896a9f6a4605


