### PR TITLE
[APP-9296] Do not attempt retries when closed

### DIFF
--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -341,8 +341,8 @@ export class RobotClient extends EventDispatcher implements Robot {
 
         this.currentRetryAttempt = attemptNumber;
 
-        // Always retry the next attempt
-        return true;
+        // Always retry the next attempt if not closed
+        return !this.closed;
       },
     };
 
@@ -634,8 +634,10 @@ export class RobotClient extends EventDispatcher implements Robot {
 
         this.currentRetryAttempt = attemptNumber;
 
-        // Abort reconnects if the the caller specifies, otherwise retry
-        return !conf.reconnectAbortSignal?.abort;
+        const aborted = conf.reconnectAbortSignal?.abort ?? false;
+
+        // Retry if not closed or aborted
+        return !aborted && !this.closed;
       },
     };
 


### PR DESCRIPTION
### Overview

I discovered this bug after testing changes from the latest dial changes. When doing exponential backoff, we don't respect the `closed` state, causing reconnect attempts to occur even if a disconnect call has happened. 

This PR adds a check before each retry attempt and stops it if closed is true. 