### PR TITLE
[RSDK-12071] Send done on client channel ready

### DIFF
--- a/src/rpc/signaling-exchange.ts
+++ b/src/rpc/signaling-exchange.ts
@@ -70,8 +70,9 @@ export class SignalingExchange {
      * should be done nor should any errors be emitted.
      */
     this.clientChannel.ready
-      .then(() => {
+      .then(async () => {
         this.exchangeDone = true;
+        await this.sendDone();
       })
       .catch(console.error); // eslint-disable-line no-console
 


### PR DESCRIPTION
### Description
* Call `sendDone()` when `clientChannel` is ready matching behavior across go and python SDKs
* This ensures that `caller_done` is set to true in the `rpc.calls` collection, allowing us to determine when an exchange is done and measure a time for it. 
### Testingl
* Pointed my app to my TS SDK with these changes and ensured that `caller_done` was set to true when successfully connecting 