### PR TITLE
[RSDK-11891] Serialize keys and options separately

### DIFF
--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -1666,10 +1666,16 @@ export class DataClient {
     },
     pipelineName?: string
   ) {
+    const serializedIndexSpec = [BSON.serialize(indexSpec.keys)];
+
+    if (indexSpec.options) {
+      serializedIndexSpec.push(BSON.serialize(indexSpec.options));
+    }
+
     await this.dataClient.createIndex({
       organizationId,
       collectionType,
-      indexSpec: [BSON.serialize(indexSpec)],
+      indexSpec: serializedIndexSpec,
       pipelineName,
     });
   }


### PR DESCRIPTION
### Description
[RSDK-11891](https://viam.atlassian.net/browse/RSDK-11891) Add SDK functionality to Create Custom Indexes on Customer Data Collections
> The SDK change was already done, but there's an issue with the indexSpec field for the CreateIndex request. It should be a multidimensional byte array (what's specified in the API protos) and not a serialized k/v object (I made a mistake when the ticket was originally under review).
* This PR fixes the issue by serializing `keys` and `options` separetely and passing `indexSpec` as a multidimensional byte array instead serializing the entire object.

[RSDK-11891]: https://viam.atlassian.net/browse/RSDK-11891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ