### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/app/app-client.spec.ts
+++ b/src/app/app-client.spec.ts
@@ -69,6 +69,8 @@ describe('AppClient tests', () => {
     secrets: [sharedSecret],
     secret: 'secret',
     fqdn: 'fqdn',
+    onlineState: pb.OnlineState.UNSPECIFIED,
+    secondsSinceOnline: 0n,
   });
 
   const logEntry = new LogEntry({
@@ -822,10 +824,13 @@ describe('AppClient tests', () => {
       nextPageToken: 'nextPage',
     });
 
+    let capturedReq: pb.GetRobotPartLogsRequest | undefined;
+
     beforeEach(() => {
       mockTransport = createRouterTransport(({ service }) => {
         service(AppService, {
-          getRobotPartLogs: () => {
+          getRobotPartLogs: (req) => {
+            capturedReq = req;
             return expectedResponse;
           },
         });
@@ -835,6 +840,13 @@ describe('AppClient tests', () => {
     it('getRobotPartLogs', async () => {
       const response = await subject().getRobotPartLogs('email');
       expect(response).toEqual(expectedResponse);
+      expect(capturedReq?.userFacingOnly).toBeUndefined();
+    });
+
+    it('getRobotPartLogs with userFacingOnly', async () => {
+      const response = await subject().getRobotPartLogs('email', undefined, undefined, '', true);
+      expect(response).toEqual(expectedResponse);
+      expect(capturedReq?.userFacingOnly).toEqual(true);
     });
   });
 

--- a/src/app/app-client.ts
+++ b/src/app/app-client.ts
@@ -899,6 +899,8 @@ export class AppClient {
    *   all log levels
    * @param pageToken Optional string indicating which page of logs to query.
    *   Defaults to the most recent
+   * @param userFacingOnly Optional boolean to indicate whether or not only
+   *   user-facing logs should be returned. Defaults to false
    * @returns The robot requested logs and the page token for the next page of
    *   logs
    */
@@ -906,13 +908,15 @@ export class AppClient {
     id: string,
     filter?: string,
     levels?: string[],
-    pageToken = ''
+    pageToken = '',
+    userFacingOnly = false
   ): Promise<GetRobotPartLogsResponse> {
     return this.client.getRobotPartLogs({
       id,
       filter,
       levels,
       pageToken,
+      userFacingOnly,
     });
   }
 

--- a/src/robot/__mocks__/robot-service.ts
+++ b/src/robot/__mocks__/robot-service.ts
@@ -1,7 +1,7 @@
 import { createRouterTransport, type Transport } from '@connectrpc/connect';
 import { RobotService } from '../../gen/robot/v1/robot_connect';
 import type { PartialMessage } from '@bufbuild/protobuf';
-import type { Operation } from '../../gen/robot/v1/robot_pb';
+import type { Operation, SendTracesResponse } from '../../gen/robot/v1/robot_pb';
 import type { ResourceName } from '../../gen/common/v1/common_pb';
 
 export const createMockRobotServiceTransport = (
@@ -12,6 +12,7 @@ export const createMockRobotServiceTransport = (
     service(RobotService, {
       resourceNames: () => ({ resources }),
       getOperations: () => ({ operations }),
+      sendTraces: () => new SendTracesResponse(),
     });
   });
 };

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -29,6 +29,7 @@ import {
   RestartModuleRequest,
   TransformPCDRequest,
   TransformPoseRequest,
+  SendTracesRequest,
 } from '../gen/robot/v1/robot_pb';
 import { DiscoveryService } from '../gen/service/discovery/v1/discovery_connect';
 import { MotionService } from '../gen/service/motion/v1/motion_connect';
@@ -44,6 +45,7 @@ import { MLModelService } from '../gen/service/mlmodel/v1/mlmodel_connect';
 import type { AccessToken, Credential } from '../main';
 import { WorldStateStoreService } from '../gen/service/worldstatestore/v1/world_state_store_connect';
 import { assertExists } from '../assert';
+import type { ResourceSpans } from '../../opentelemetry/proto/trace/v1/trace_pb';
 
 const DIAL_ABORTED_ERROR_MESSAGE = 'Dial operation aborted';
 
@@ -1206,5 +1208,26 @@ export class RobotClient extends EventDispatcher implements Robot {
       request.idOrName.value = moduleName;
     }
     await this.robotService.restartModule(request);
+  }
+
+  /**
+   * Send traces to the robot.
+   *
+   * @example
+   *
+   * ```ts
+   * import { ResourceSpans } from '../../gen/opentelemetry/proto/trace/v1/trace_pb';
+   *
+   * const resourceSpans = [new ResourceSpans()]; // Populate with actual trace data
+   * await machine.sendTraces(resourceSpans);
+   * ```
+   *
+   * @param resourceSpans - A list of OpenTelemetry ResourceSpans to send.
+   * @group Traces
+   * @alpha
+   */
+  async sendTraces(resourceSpans: ResourceSpans[]) {
+    const request = new SendTracesRequest({ resourceSpans });
+    await this.robotService.sendTraces(request);
   }
 }

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -3,6 +3,7 @@ import { MachineConnectionEvent } from '../events';
 import type { PoseInFrame, Transform } from '../gen/common/v1/common_pb';
 import * as proto from '../gen/robot/v1/robot_pb';
 import type { ResourceName } from '../types';
+import type { ResourceSpans } from '../gen/opentelemetry/proto/trace/v1/trace_pb';
 
 export type CloudMetadata = proto.GetCloudMetadataResponse;
 
@@ -241,4 +242,22 @@ export interface Robot {
    * @alpha
    */
   restartModule(moduleId?: string, moduleName?: string): Promise<void>;
+
+  /**
+   * Send traces to the robot.
+   *
+   * @example
+   *
+   * ```ts
+   * import { ResourceSpans } from '../../gen/opentelemetry/proto/trace/v1/trace_pb';
+   *
+   * const resourceSpans = [new ResourceSpans()]; // Populate with actual trace data
+   * await machine.sendTraces(resourceSpans);
+   * ```
+   *
+   * @param resourceSpans - A list of OpenTelemetry ResourceSpans to send.
+   * @group Traces
+   * @alpha
+   */
+  sendTraces(resourceSpans: ResourceSpans[]): Promise<void>;
 }


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This PR introduces updates to the App and Robot services:

*   **App Service:**
    *   The `RobotPart` data model now includes new fields: `onlineState` (enum) and `secondsSinceOnline` (bigint).
    *   The `getRobotPartLogs` method has been enhanced to accept an optional `userFacingOnly` boolean parameter, allowing callers to filter for user-facing logs.
*   **Robot Service:**
    *   A new `sendTraces` RPC method has been added to the `RobotService`. This allows clients to send OpenTelemetry trace data (`ResourceSpans`) to the robot.