### PR TITLE
RSDK-12734: add viam_client metadata to grpc request

### DIFF
--- a/src/robot/session-transport.ts
+++ b/src/robot/session-transport.ts
@@ -88,11 +88,11 @@ export default class SessionTransport implements Transport {
   ): Promise<StreamResponse<I, O>> {
     const newHeaders = cloneHeaders(header);
     const methodPath = `/${service.typeName}/${method.name}`;
-    
+
     for (const [key, value] of clientHeaders) {
       newHeaders.set(key, value);
     }
-    
+
     if (SessionManager.heartbeatMonitoredMethods[methodPath] ?? false) {
       const md = await this.getSessionMetadata();
       for (const [key, value] of md) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import { DoCommandRequest, DoCommandResponse } from './gen/common/v1/common_pb';
 import type { Options } from './types';
 
 export const clientHeaders = new Headers({
-  'viam_client': `typescript;v${__VERSION__};${apiVersion}`,
+  viam_client: `typescript;v${__VERSION__};${apiVersion}`,
 });
 
 type doCommand = (


### PR DESCRIPTION
This PR fixes a bug where tyepscript metadata isn't being sent in grpc calls.

Tested by adding this script into the rdk:
```
	values := meta.Get(viamClientInfoMetadataKey)
	if len(values) == 1 {
		ctx = context.WithValue(ctx, viamClientInfoKeyID, values[0])
		golog.Global().Info("viam_client WAS set in the incoming gRPC headers for", info.FullMethod, "value:", values[0])
	} else {
		golog.Global().Error("viam_client was NOT set in the incoming gRPC headers for", info.FullMethod)
```
and then created a typescript app that calls for data from viam server

Output logs:
<img width="847" height="87" alt="image" src="https://github.com/user-attachments/assets/630920b0-46ee-4506-b3ee-3e1cbe85550b" />
