### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -919,6 +919,7 @@ describe('DataClient tests', () => {
         yMinNormalized: 0,
         yMaxNormalized: 1,
         xMaxNormalized: 1,
+        confidence: 0.9,
       });
 
       const promise = await subject().addBoundingBoxToImageById(
@@ -927,7 +928,8 @@ describe('DataClient tests', () => {
         0,
         0,
         1,
-        1
+        1,
+        0.9
       );
       expect(capReq).toStrictEqual(expectedRequest);
       expect(promise).toEqual('bboxId');
@@ -941,10 +943,35 @@ describe('DataClient tests', () => {
         yMinNormalized: 0,
         yMaxNormalized: 1,
         xMaxNormalized: 1,
+        confidence: 0.8,
       });
 
       const promise = await subject().addBoundingBoxToImageById(
         binaryId1,
+        'label',
+        0,
+        0,
+        1,
+        1,
+        0.8
+      );
+      expect(capReq).toStrictEqual(expectedRequest);
+      expect(promise).toEqual('bboxId');
+    });
+
+    it('add bounding box to image with no confidence', async () => {
+      const expectedRequest = new AddBoundingBoxToImageByIDRequest({
+        binaryDataId: binaryDataId1,
+        label: 'label',
+        xMinNormalized: 0,
+        yMinNormalized: 0,
+        yMaxNormalized: 1,
+        xMaxNormalized: 1,
+        confidence: undefined,
+      });
+
+      const promise = await subject().addBoundingBoxToImageById(
+        binaryDataId1,
         'label',
         0,
         0,

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -796,7 +796,8 @@ export class DataClient {
    *   0.3,
    *   0.3,
    *   0.6,
-   *   0.6
+   *   0.6,
+   *   0.9
    * );
    * ```
    *
@@ -813,6 +814,7 @@ export class DataClient {
    *   to 1
    * @param yMaxNormalized The max Y value of the bounding box normalized from 0
    *   to 1
+   * @param confidence Optional confidence score for the bounding box, from 0 to 1.
    * @returns The bounding box ID
    */
   async addBoundingBoxToImageById(
@@ -821,7 +823,8 @@ export class DataClient {
     xMinNormalized: number,
     yMinNormalized: number,
     xMaxNormalized: number,
-    yMaxNormalized: number
+    yMaxNormalized: number,
+    confidence?: number
   ) {
     if (typeof binaryId === 'string') {
       const resp = await this.dataClient.addBoundingBoxToImageByID({
@@ -831,6 +834,7 @@ export class DataClient {
         yMinNormalized,
         xMaxNormalized,
         yMaxNormalized,
+        confidence,
       });
       return resp.bboxId;
     }
@@ -842,6 +846,7 @@ export class DataClient {
       yMinNormalized,
       xMaxNormalized,
       yMaxNormalized,
+      confidence,
     });
     return resp.bboxId;
   }

--- a/src/components/arm/arm.ts
+++ b/src/components/arm/arm.ts
@@ -3,7 +3,7 @@ import type { Pose, Resource } from '../../types';
 
 import * as armApi from '../../gen/component/arm/v1/arm_pb';
 import type { Geometry, Mesh } from '../../gen/common/v1/common_pb';
-import type { KinematicsData } from '../../utils';
+import type { GetKinematicsResult, KinematicsData } from '../../utils';
 
 export type ArmJointPositions = PlainMessage<armApi.JointPositions>;
 
@@ -68,8 +68,10 @@ export interface Arm extends Resource {
    * For more information, see [Arm
    * API](https://docs.viam.com/dev/reference/apis/components/arm/#getkinematics).
    * ```
+   *
+   * @returns The kinematics data and a map of URDF mesh file paths to mesh data.
    */
-  getKinematics: (extra?: Struct) => Promise<KinematicsData>;
+  getKinematics: (extra?: Struct) => Promise<GetKinematicsResult>;
 
   /**
    * Move the end of the arm to the pose.

--- a/src/components/arm/client.ts
+++ b/src/components/arm/client.ts
@@ -19,6 +19,7 @@ import {
 } from '../../utils';
 import type { Arm } from './arm';
 import { Get3DModelsRequest, Mesh } from '../../gen/common/v1/common_pb';
+import { GetKinematicsResult } from '../../utils';
 
 /**
  * A gRPC-web client for the Arm component.
@@ -62,7 +63,7 @@ export class ArmClient implements Arm {
     );
   }
 
-  async getKinematics(extra = {}, callOptions = this.callOptions) {
+  async getKinematics(extra = {}, callOptions = this.callOptions): Promise<GetKinematicsResult> {
     return getKinematicsFromClient(
       this.client.getKinematics,
       this.name,

--- a/src/components/gantry/client.ts
+++ b/src/components/gantry/client.ts
@@ -17,6 +17,7 @@ import {
   getGeometriesFromClient,
 } from '../../utils';
 import type { Gantry } from './gantry';
+import type { GetKinematicsResult } from '../../utils';
 
 /**
  * A gRPC-web client for the Gantry component.
@@ -44,7 +45,7 @@ export class GantryClient implements Gantry {
     );
   }
 
-  async getKinematics(extra = {}, callOptions = this.callOptions) {
+  async getKinematics(extra = {}, callOptions = this.callOptions): Promise<GetKinematicsResult> {
     return getKinematicsFromClient(
       this.client.getKinematics,
       this.name,

--- a/src/components/gantry/gantry.ts
+++ b/src/components/gantry/gantry.ts
@@ -1,7 +1,7 @@
-import type { Struct } from '@bufbuild/protobuf';
-import type { Resource } from '../../types';
-import type { Geometry } from '../../gen/common/v1/common_pb';
-import type { KinematicsData } from '../../utils';
+import type { Struct } from '@bufbuild/protobuf'
+import type { Resource } from '../../types'
+import type { Geometry } from '../../gen/common/v1/common_pb'
+import type { GetKinematicsResult, KinematicsData } from '../../utils'
 
 /** Represents a physical gantry that exists in three-dimensional space. */
 export interface Gantry extends Resource {
@@ -20,7 +20,7 @@ export interface Gantry extends Resource {
    * For more information, see [Gantry
    * API](https://docs.viam.com/dev/reference/apis/components/gantry/#getgeometries).
    */
-  getGeometries: (extra?: Struct) => Promise<Geometry[]>;
+  getGeometries: (extra?: Struct) => Promise<Geometry[]>
 
   /**
    * Get the kinematics information associated with the gantry.
@@ -37,7 +37,7 @@ export interface Gantry extends Resource {
    * For more information, see [Gantry
    * API](https://docs.viam.com/dev/reference/apis/components/gantry/#getkinematics).
    */
-  getKinematics: (extra?: Struct) => Promise<KinematicsData>;
+  getKinematics: (extra?: Struct) => Promise<GetKinematicsResult>
 
   /**
    * Move each axis of the gantry to the positionsMm at the speeds in
@@ -67,7 +67,7 @@ export interface Gantry extends Resource {
     positionsMm: number[],
     speedsMmPerSec: number[],
     extra?: Struct
-  ) => Promise<void>;
+  ) => Promise<void>
 
   /**
    * Get the current position of each axis.
@@ -86,7 +86,7 @@ export interface Gantry extends Resource {
    *
    * @returns A list of the current position of each axis in millimeters.
    */
-  getPosition: (extra?: Struct) => Promise<number[]>;
+  getPosition: (extra?: Struct) => Promise<number[]>
 
   /**
    * Runs the homing sequence to find the start and end positions of the gantry
@@ -107,7 +107,7 @@ export interface Gantry extends Resource {
    * @returns A bool representing whether the gantry has run the homing sequence
    *   successfully.
    */
-  home: (extra?: Struct) => Promise<boolean>;
+  home: (extra?: Struct) => Promise<boolean>
 
   /**
    * Get the lengths of the axes of the gantry in millimeters.
@@ -126,7 +126,7 @@ export interface Gantry extends Resource {
    *
    * @returns A list of the length of each axis in millimeters.
    */
-  getLengths: (extra?: Struct) => Promise<number[]>;
+  getLengths: (extra?: Struct) => Promise<number[]>
 
   /**
    * Stop the motion of the gantry.
@@ -143,7 +143,7 @@ export interface Gantry extends Resource {
    * For more information, see [Gantry
    * API](https://docs.viam.com/dev/reference/apis/components/gantry/#stop).
    */
-  stop: (extra?: Struct) => Promise<void>;
+  stop: (extra?: Struct) => Promise<void>
 
   /**
    * Get if the gantry is currently moving.
@@ -161,5 +161,5 @@ export interface Gantry extends Resource {
    * For more information, see [Gantry
    * API](https://docs.viam.com/dev/reference/apis/components/gantry/#ismoving).
    */
-  isMoving: () => Promise<boolean>;
+  isMoving: () => Promise<boolean>
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ import {
   GetGeometriesRequest,
   GetGeometriesResponse,
   Geometry,
+  Mesh,
 } from './gen/common/v1/common_pb';
 import type { Options, Vector3 } from './types';
 import type { Frame } from './gen/app/v1/robot_pb';
@@ -108,6 +109,12 @@ export interface KinematicsData {
   links: Frame[];
 }
 
+/** Shared type for kinematics return value */
+export interface GetKinematicsResult {
+  kinematicsData: KinematicsData;
+  meshesByUrdfFilepath: { [key: string]: Mesh };
+}
+
 type getKinematics = (
   request: PartialMessage<GetKinematicsRequest>,
   options?: CallOptions
@@ -119,7 +126,7 @@ export const getKinematicsFromClient = async function getKinematicsFromClient(
   name: string,
   extra: Struct = Struct.fromJson({}),
   callOptions: CallOptions = {}
-): Promise<KinematicsData> {
+): Promise<GetKinematicsResult> {
   const request = new GetKinematicsRequest({
     name,
     extra,
@@ -129,8 +136,12 @@ export const getKinematicsFromClient = async function getKinematicsFromClient(
 
   const decoder = new TextDecoder('utf8');
   const jsonString = decoder.decode(response.kinematicsData);
+  const parsedKinematicsData = JSON.parse(jsonString) as KinematicsData;
 
-  return JSON.parse(jsonString) as KinematicsData;
+  return {
+    kinematicsData: parsedKinematicsData,
+    meshesByUrdfFilepath: response.meshesByUrdfFilepath,
+  };
 };
 
 type getGeometries = (


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This update introduces the following changes:

*   **Bounding Box Confidence:** The `DataClient.addBoundingBoxToImageById` method now accepts an optional `confidence` parameter (double), allowing callers to specify the confidence score associated with a bounding box. Tests have been updated to reflect this.
*   **Kinematics Response Enhancement:** The `getKinematics` methods for `Arm` and `Gantry` components have been updated. Their responses now include a map (`meshesByUrdfFilepath`) containing mesh data keyed by URDF file paths, alongside the existing kinematics data.
*   **Naming Refactor:** Field names within the `app` service protobuf definitions have been updated for clarity: `imports` is now `fragments` in `FragmentImportList`, and `fragmentImports` is now `defaultFragments` in `UpdateOrganizationRequest`.