### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -1801,7 +1801,7 @@ describe('DataSyncClient tests', () => {
         type: DataType.BINARY_SENSOR,
         tags,
         datasetIds,
-        mimeType,
+        mimeType_10: mimeType,
         fileExtension: '',
       });
       expectedReq.metadata = expectedMd;

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -1478,7 +1478,7 @@ export class DataClient {
       tags: resolvedTags,
       fileExtension,
       datasetIds: resolvedDatasetIds,
-      mimeType,
+      mimeType_10: mimeType,
     });
 
     const sensorData = new SensorData({

--- a/src/components/camera/camera.ts
+++ b/src/components/camera/camera.ts
@@ -3,6 +3,7 @@ import type { Timestamp } from '@bufbuild/protobuf';
 import type {
   DistortionParameters,
   IntrinsicParameters,
+  ExtrinsicParameters,
 } from '../../gen/component/camera/v1/camera_pb';
 import type { Resource } from '../../types';
 import type { Geometry } from '../../gen/common/v1/common_pb';
@@ -16,6 +17,8 @@ export interface Properties {
   distortionParameters?: DistortionParameters;
   /** Camera frame rate parameters, if available. */
   frameRate?: number;
+  /** Camera extrinsic parameters, if available. */
+  extrinsicParameters?: ExtrinsicParameters;
 }
 
 export interface NamedImage {

--- a/src/components/camera/client.ts
+++ b/src/components/camera/client.ts
@@ -1,6 +1,6 @@
 import { type JsonValue, Struct, Timestamp } from '@bufbuild/protobuf';
 import type { CallOptions, Client } from '@connectrpc/connect';
-import { GetPropertiesRequest } from '../../gen/component/base/v1/base_pb';
+import { GetPropertiesRequest, GetPropertiesResponse } from '../../gen/component/camera/v1/camera_pb';
 import { CameraService } from '../../gen/component/camera/v1/camera_connect';
 import {
   GetImagesRequest,
@@ -9,7 +9,7 @@ import {
 import type { RobotClient } from '../../robot';
 import type { Options } from '../../types';
 import { doCommandFromClient } from '../../utils';
-import type { Camera, MimeType, ResponseMetadata } from './camera';
+import type { Camera, MimeType, ResponseMetadata, Properties } from './camera';
 import { GetGeometriesRequest } from '../../gen/common/v1/common_pb';
 
 const PointCloudPCD: MimeType = 'pointcloud/pcd';
@@ -80,14 +80,15 @@ export class CameraClient implements Camera {
     return resp.pointCloud;
   }
 
-  async getProperties(callOptions = this.callOptions) {
+  async getProperties(callOptions = this.callOptions): Promise<Properties> {
     const request = new GetPropertiesRequest({
       name: this.name,
     });
 
     this.options.requestLogger?.(request);
 
-    return this.client.getProperties(request, callOptions);
+    const response = await this.client.getProperties(request, callOptions);
+    return { supportsPcd: response.supportsPcd, intrinsicParameters: response.intrinsicParameters, distortionParameters: response.distortionParameters, frameRate: response.frameRate, extrinsicParameters: response.extrinsicParameters, };
   }
 
   async doCommand(

--- a/src/services/data-manager/data-manager.ts
+++ b/src/services/data-manager/data-manager.ts
@@ -8,7 +8,7 @@ export interface DataManager extends Resource {
     binaryData: Uint8Array,
     tags: string[],
     datasetIds: string[],
-    mimeType: MimeType,
+    mimeType: string,
     extra?: Struct
   ) => Promise<void>;
 }


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
Here's a summary of the changes:

*   **Data Capture:** Updated `DataCaptureMetadata` to use a new string-based `mimeType` field (field 10), deprecating the older enum-based field (field 3). This change affects how binary data uploads are processed and tested.
*   **Camera Component:** Enhanced the `Camera.getProperties` method to include extrinsic parameters (translation and orientation relative to a reference frame) in its response, providing more comprehensive information about the camera's pose.