### PR TITLE
RSDK-8273: Vanilla example firefox workaround

### DIFF
--- a/examples/vanilla/README.md
+++ b/examples/vanilla/README.md
@@ -40,7 +40,6 @@ Firefox has a limitation with WebRTC when accessing via `localhost` due to netwo
    Add-Content -Path "$env:SystemRoot\System32\drivers\etc\hosts" -Value "`n127.0.0.1 dev.local"
    ```
 
-
 2. Start the dev server with the local hostname:
 
    ```bash


### PR DESCRIPTION
Firefox has a known issue with webrtc connections on localhost (See [stackoverflow thread](https://stackoverflow.com/questions/72862092/webrtc-ice-failed-in-firefox-but-working-in-ms-edge)) where it will ```fail to find default addresses```. This workaround gets around firefox's security setup by setting localhost to dev.local to firefox

Here are things I tried that didn't work:
❌ turning off firewall
❌ local network already enabled for firefox
❌ Using google stun servers iceServers ```stun:stun2.1.google.com:19302```
❌ setting media.peerconnection.ice.loopback to true