### PR TITLE
[RSDK-13154] Pass in API key to SetSmartMachineCredentialsRequest in Provisioning client TypeScript SDK

### DIFF
--- a/src/app/provisioning-client.spec.ts
+++ b/src/app/provisioning-client.spec.ts
@@ -4,6 +4,7 @@ import { createRouterTransport, type Transport } from '@connectrpc/connect';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ProvisioningService } from '../gen/provisioning/v1/provisioning_connect';
 import {
+  APIKey,
   CloudConfig,
   GetNetworkListResponse,
   GetSmartMachineStatusResponse,
@@ -41,10 +42,15 @@ const testSmartMachineStatus = new GetSmartMachineStatusResponse({
 const type = 'type';
 const ssid = 'ssid';
 const psk = 'psk';
+const apiKey = new APIKey({
+  id: 'api_key_id',
+  key: 'api_key_value',
+});
 const cloud = new CloudConfig({
   id: 'id',
   secret: 'secret',
   appAddress: 'app_address',
+  apiKey,
 });
 
 let setNetworkCredentialsReq: SetNetworkCredentialsRequest;

--- a/src/app/provisioning-client.ts
+++ b/src/app/provisioning-client.ts
@@ -55,4 +55,4 @@ export class ProvisioningClient {
   }
 }
 
-export { CloudConfig } from '../gen/provisioning/v1/provisioning_pb';
+export { APIKey, CloudConfig } from '../gen/provisioning/v1/provisioning_pb';


### PR DESCRIPTION
### Description

[RSDK-13154](https://viam.atlassian.net/browse/RSDK-13154) Pass in API key to SetSmartMachineCredentialsRequest in Provisioning client SDKs

* `SetSmartMachineCredentialsRequest` was updated to include an `APIKey` field so that devices can be provisioned with an APIKey. This PR updates the TypeScript SDK to export the API key type so that the cloud config param for the request can be constructed with it

Behavior table:
Old Agent,  Old SDK —>  no API key provisioning
New Agent, Old SDK —> Agent can handle provisioning requests without an API key
Old Agent, New SDK —> APIKey field ignored, provisioned without it
New Agent, New SDK —> API Key provisioned 

[RSDK-13154]: https://viam.atlassian.net/browse/RSDK-13154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ