### PR TITLE
feat: export video service things from main

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -421,6 +421,8 @@ export * as visionApi from './gen/service/vision/v1/vision_pb';
 
 export * from './services/world-state-store';
 
+export * from './services/video';
+
 export {
   GenericClient as GenericServiceClient,
   type Generic as GenericService,


### PR DESCRIPTION
# Description
https://viam.atlassian.net/browse/APP-15217

In this ticket we saw the DoCommand test card for video sevice were not working. We need to use the VideoClient but it is not exported from the ts-sdk. This change exports the video service exports from main.ts

# Testing 
- ran locally using updated ts-sdk w/ local app and saw could properly sue video service control card for doCommand
<img width="1454" height="641" alt="Screenshot 2026-02-12 at 11 05 05 AM" src="https://github.com/user-attachments/assets/0bc77991-4710-4b6f-862d-5d2223166946" />
