### PR TITLE
RSDK-13420 Remove deprecated binaryDataCaptureUpload signature

### DIFF
--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -1698,7 +1698,6 @@ describe('DataSyncClient tests', () => {
   const componentType = 'testComponentType';
   const componentName = 'testComponentName';
   const methodName = 'testMethodName';
-  const fileExtension = '.png';
   const tags = ['testTag1', 'testTag2'];
   const datasetIds = ['dataset1', 'dataset2'];
   const timeRequested1 = new Date(1970, 1, 1, 1, 1, 1);
@@ -1783,36 +1782,7 @@ describe('DataSyncClient tests', () => {
       });
     });
 
-    it('binary data capture upload (legacy signature)', async () => {
-      metadata.type = DataType.BINARY_SENSOR;
-      metadata.fileExtension = fileExtension;
-      expectedRequest.metadata = metadata;
-      expectedRequest.metadata.datasetIds = datasetIds;
-      const sensorData = new SensorData();
-      const sensorMetadata = new SensorMetadata();
-      sensorMetadata.timeRequested = Timestamp.fromDate(timeRequested1);
-      sensorMetadata.timeReceived = Timestamp.fromDate(timeReceived1);
-      sensorData.metadata = sensorMetadata;
-      sensorData.data.case = 'binary';
-      sensorData.data.value = binaryData;
-      expectedRequest.sensorContents = [sensorData];
-
-      const response = await subject().binaryDataCaptureUpload(
-        binaryData,
-        partId,
-        componentType,
-        componentName,
-        methodName,
-        fileExtension,
-        dataRequestTimes1,
-        tags,
-        datasetIds
-      );
-      expect(capReq).toStrictEqual(expectedRequest);
-      expect(response).toStrictEqual('fileId');
-    });
-
-    it('binary data capture upload (options overload)', async () => {
+    it('binary data capture upload', async () => {
       const mimeType = 'image/png';
 
       const expectedReq = new DataCaptureUploadRequest();

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -1419,7 +1419,7 @@ export class DataClient {
    *   `tags`, and `datasetIds`.
    * @returns The binary data ID of the uploaded data
    */
-  binaryDataCaptureUpload(
+  async binaryDataCaptureUpload(
     binaryData: Uint8Array,
     partId: string,
     componentType: string,
@@ -1427,76 +1427,17 @@ export class DataClient {
     methodName: string,
     dataRequestTimes: [Date, Date],
     options?: BinaryDataCaptureUploadOptions
-  ): Promise<string>;
-
-  /**
-   * @deprecated Use the overload that takes `(dataRequestTimes, options)` to
-   *   provide `mimeType`, `fileExtension`, `tags`, and `datasetIds`.
-   */
-  binaryDataCaptureUpload(
-    binaryData: Uint8Array,
-    partId: string,
-    componentType: string,
-    componentName: string,
-    methodName: string,
-    fileExtension: string,
-    dataRequestTimes: [Date, Date],
-    tags?: string[],
-    datasetIds?: string[]
-  ): Promise<string>;
-
-  async binaryDataCaptureUpload(
-    binaryData: Uint8Array,
-    partId: string,
-    componentType: string,
-    componentName: string,
-    methodName: string,
-    fileExtensionOrDataRequestTimes: string | [Date, Date],
-    dataRequestTimesOrOptions?:
-      | [Date, Date]
-      | BinaryDataCaptureUploadOptions
-      | undefined,
-    tags?: string[],
-    datasetIds?: string[]
   ): Promise<string> {
-    const isLegacySignature =
-      typeof fileExtensionOrDataRequestTimes === 'string';
-    if (isLegacySignature && !dataRequestTimesOrOptions) {
-      throw new Error(
-        'binaryDataCaptureUpload called with legacy signature but missing dataRequestTimes'
-      );
-    }
-
-    const dataRequestTimes: [Date, Date] = isLegacySignature
-      ? (dataRequestTimesOrOptions as [Date, Date])
-      : fileExtensionOrDataRequestTimes;
-
-    const options = isLegacySignature
-      ? undefined
-      : (dataRequestTimesOrOptions as
-          | BinaryDataCaptureUploadOptions
-          | undefined);
-
-    const fileExtension = isLegacySignature
-      ? fileExtensionOrDataRequestTimes
-      : (options?.fileExtension ?? '');
-
-    const mimeType = options?.mimeType ?? '';
-    const resolvedTags = isLegacySignature ? tags : options?.tags;
-    const resolvedDatasetIds = isLegacySignature
-      ? datasetIds
-      : options?.datasetIds;
-
     const metadata = new UploadMetadata({
       partId,
       componentType,
       componentName,
       methodName,
       type: DataType.BINARY_SENSOR,
-      tags: resolvedTags,
-      fileExtension,
-      datasetIds: resolvedDatasetIds,
-      mimeType,
+      tags: options?.tags,
+      fileExtension: options?.fileExtension ?? '',
+      datasetIds: options?.datasetIds,
+      mimeType: options?.mimeType ?? '',
     });
 
     const sensorData = new SensorData({

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ export {
 } from './app/viam-transport';
 
 export {
+  type BinaryDataCaptureUploadOptions,
   type BinaryID,
   type DataClient,
   type FilterOptions,


### PR DESCRIPTION
## Summary
- Removes the deprecated `binaryDataCaptureUpload` overload that accepted positional `fileExtension`, `tags`, and `datasetIds` parameters
- Simplifies the implementation to only accept the options struct introduced in #736
- Exports `BinaryDataCaptureUploadOptions` from the public API

## Breaking change
This is a breaking change for callers using the old positional-parameter signature. This PR will be merged after the deprecation has been communicated to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)