### PR TITLE
Claude cli git commit gh pr bug workaround

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -119,6 +119,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           settings: .claude/settings.ci.json
+          use_commit_signing: true
           allowed_bots: "claude[bot]"
           prompt: |
             CI failed on PR #${{ steps.check.outputs.pr_number }} (fix attempt ${{ steps.check.outputs.attempt }} of 2).
@@ -138,7 +139,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 30
-            --allowedTools "Edit,Read,Write,Glob,Grep,Bash(npm run _prettier*),Bash(npm run lint:prettier*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *)"
+            --allowedTools "Edit,Read,Write,Glob,Grep,mcp__github_file_ops__commit_files,Bash(npm run _prettier*),Bash(npm run lint:prettier*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *)"
 
       - name: Comment on PR if max retries exhausted
         if: steps.check.outputs.max_reached == 'true'

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           settings: .claude/settings.ci.json
+          use_commit_signing: true
           prompt: |
             Implement the following Jira ticket:
 
@@ -64,8 +65,8 @@ jobs:
           claude_args: |
             --model claude-opus-4-6
             --max-turns 50
-            --append-system-prompt "Before modifying any file, explore the relevant code first. Consider alternative approaches and select the smallest, safest change that reuses existing patterns. Do not introduce new abstractions or refactor beyond what is needed."
-            --allowedTools "Edit,Read,Write,Glob,Grep,Bash(npm run _prettier*),Bash(npm run lint:prettier*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*)"
+            --append-system-prompt "Before modifying any file, explore the relevant code first. Consider alternative approaches and select the smallest, safest change that reuses existing patterns. Do not introduce new abstractions or refactor beyond what is needed. CRITICAL: For PRs, write the body to /tmp/pr-body.md using the Write tool, then run gh pr create --title 'Title' --body-file /tmp/pr-body.md. NEVER pass multi-line strings directly to --body."
+            --allowedTools "Edit,Read,Write,Glob,Grep,mcp__github_file_ops__commit_files,Bash(npm run _prettier*),Bash(npm run lint:prettier*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*)"
       - name: Notify Slack of failure
         # slackapi/slack-github-action@v2.1.1
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           settings: .claude/settings.ci.json
+          use_commit_signing: true
           allowed_bots: "claude[bot]"
           track_progress: true
           prompt: |
@@ -94,7 +95,7 @@ jobs:
             --model claude-sonnet-4-6
             --max-turns 30
             --append-system-prompt "You are a demanding code reviewer. Your job is to catch bugs, security issues, and convention violations that the implementing agent missed. Be thorough and skeptical. Do not rubber-stamp changes. If something looks suspicious, investigate it fully before approving."
-            --allowedTools "Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(npm run _prettier*),Bash(npm run lint:prettier*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr review*),Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*)"
+            --allowedTools "Edit,Read,Write,Glob,Grep,mcp__github_file_ops__commit_files,mcp__github_inline_comment__create_inline_comment,Bash(npm run _prettier*),Bash(npm run lint:prettier*),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr review*),Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*)"
 
       - name: Notify Slack of failure
         # slackapi/slack-github-action@v2.1.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ These rules apply when running in GitHub Actions (CI) workflows:
 - For bulk edits (same change across many files): work in small batches of up to 5 files at a time — Read 5 files, then Edit those 5 files, then move to the next 5. Do NOT read all files at once then edit all at once — the Edit tool may lose track of reads from large batches. Do NOT use `Bash(sed -i ...)` — it is blocked by the sandbox.
 - Always Read a file (full read, no offset/limit) before Editing it.
 - Do NOT use Task subagents for file editing. Use the Edit tool directly from the main agent. Bash-type subagents only have the Bash tool — they cannot use Edit, Grep, or Glob.
-- For `git commit -m` and `gh pr create --body`, use simple single-line `-m "message"` strings — no heredocs, `$(cat ...)`, or embedded newlines.
+- For commits, prefer `mcp__github_file_ops__commit_files` (available when `use_commit_signing` is enabled). Fall back to `git commit -m "single-line message"` if needed.
+- For PRs, write the body to `/tmp/pr-body.md` using the Write tool, then run `gh pr create --title "Title" --body-file /tmp/pr-body.md`. NEVER pass multi-line strings directly to `--body`.
 
 ## Implementation
 


### PR DESCRIPTION
Trying to work aorund Claude's built-in system prompt tells it to use heredocs for git commits (e.g., git commit -m "$(cat <<'EOF'\n...\nEOF\n)"). The Bash(git commit *) glob pattern doesn't match strings containing newlines. So Claude's default behavior directly conflicts with the permission system. 

Other reports https://github.com/anthropics/claude-code/issues/18713 