### PR TITLE
Claude commit workflows should use a PAT with write permissions

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -114,6 +114,7 @@ jobs:
         with:
           ref: ${{ steps.check.outputs.branch }}
           fetch-depth: 1
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Install dependencies
         if: steps.check.outputs.should_fix == 'true'

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -61,7 +61,6 @@ jobs:
             - Branch name MUST start with `claude/` prefix (e.g., `claude/rsdk-12345/short-description`).
             - For gh pr create, write the body to /tmp/pr-body.md using the Write tool, then use --body-file /tmp/pr-body.md. NEVER pass multi-line strings directly to --body.
             - Include the Jira ticket ID in the PR title.
-          show_full_output: true
           claude_args: |
             --model claude-opus-4-6
             --max-turns 50

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.branch }}
           fetch-depth: 1
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Install dependencies
         if: steps.pr.outputs.found == 'true'


### PR DESCRIPTION
this will allow CI workflow to run after commits made by claude