### PR TITLE
APP-15413 Add filter to DeleteTabularData

### DIFF
--- a/src/app/data-client.spec.ts
+++ b/src/app/data-client.spec.ts
@@ -33,6 +33,7 @@ import {
   DeleteBinaryDataByIDsResponse,
   DeleteIndexRequest,
   DeleteIndexResponse,
+  DeleteTabularDataRequest,
   DeleteTabularDataResponse,
   ExportTabularDataRequest,
   ExportTabularDataResponse,
@@ -648,11 +649,15 @@ describe('DataClient tests', () => {
     });
 
     it('delete tabular data with filter', async () => {
-      const filter: DeleteTabularFilter = {
+      const deleteTabularFilter = new DeleteTabularFilter({
         locationIds: ['location-1'],
         componentName: 'camera',
-      };
-      const promise = await subject().deleteTabularData('orgId', 20, filter);
+      });
+      const promise = await subject().deleteTabularData(
+        'orgId',
+        20,
+        deleteTabularFilter
+      );
       expect(promise).toEqual(10n);
       expect(capturedRequest?.filter).toBeDefined();
       expect(capturedRequest?.filter?.locationIds).toEqual(['location-1']);

--- a/src/app/data-client.ts
+++ b/src/app/data-client.ts
@@ -570,7 +570,7 @@ export class DataClient {
    *   10,
    *   {
    *     locationIds: ['location-id'],
-   *     componentName: 'camera'
+   *     componentName: 'camera',
    *   }
    * );
    * ```
@@ -579,12 +579,12 @@ export class DataClient {
    * API](https://docs.viam.com/dev/reference/apis/data-client/#deletetabulardata).
    *
    * @param organizationId The ID of organization to delete data from
-   * @param deleteOlderThanDays Delete data that was captured more than this many
-   *   days ago. For example, a value of 10 deletes any data that was captured
-   *   more than 10 days ago. A value of 0 deletes all existing data.
+   * @param deleteOlderThanDays Delete data that was captured more than this
+   *   many days ago. For example, a value of 10 deletes any data that was
+   *   captured more than 10 days ago. A value of 0 deletes all existing data.
    * @param filter Optional filter to further constrain which data is deleted.
-   *   If provided, only data matching the filter will be deleted.
-   *   If omitted, data is deleted based on organization_id and delete_older_than_days.
+   *   If provided, only data matching the filter will be deleted. If omitted,
+   *   data is deleted based on organization_id and delete_older_than_days.
    * @returns The number of items deleted
    */
   async deleteTabularData(


### PR DESCRIPTION
## Summary
  Add optional `filter` parameter to `deleteTabularData` method.

  ## Changes
  - Added optional `filter?: PartialMessage<DeleteTabularFilter>` parameter
  - Updated JSDoc with filter usage examples
  - Added `DeleteTabularFilter` to imports
  - Added two test cases for filter functionality

  ## Usage Examples

  **Without filter (existing behavior):**
  ```typescript
  const deletedCount = await client.deleteTabularData(
    'org-id',
    5
  );


  With filter:
  import type { DeleteTabularFilter } from '@viamrobotics/sdk';

  const filter: DeleteTabularFilter = {
    locationIds: ['location-1'],
    componentName: 'camera-1',
  };

  const deletedCount = await client.deleteTabularData(
    'org-id',
    5,
    filter
  );

  Behavior

  - If filter is omitted or undefined, behavior is unchanged
  - If filter is provided, deletion is constrained by filter fields (AND logic)
  - Uses PartialMessage<DeleteTabularFilter> for convenient partial object creation

  Backward Compatibility

  ✅ Fully backward compatible - existing code continues to work without changes

  Testing

  - Existing test delete tabular data passes (no filter)
  - New test delete tabular data with filter verifies filter with multiple fields
  - New test delete tabular data with empty filter verifies empty filter behavior

  Dependencies

  - Requires API proto changes from APP-15411

  Related PRs

  - api PR: [link to APP-15411]
  - app PR: [link to APP-15412]