### PR TITLE
Remove premature CONNECTED event from ICE handler

### DIFF
--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -1074,9 +1074,7 @@ export class RobotClient extends EventDispatcher implements Robot {
            * connection getting closed, so restarting ice is not a valid way to
            * recover.
            */
-          if (this.peerConn?.iceConnectionState === 'connected') {
-            this.emit(MachineConnectionEvent.CONNECTED, {});
-          } else if (this.peerConn?.iceConnectionState === 'closed') {
+          if (this.peerConn?.iceConnectionState === 'closed') {
             this.onDisconnect();
           }
         };


### PR DESCRIPTION
Timeline:
- bae6276 (RSDK-3131): Added ICE handler, only handled 'closed'. Correct.
- 45aa325 (RSDK-2866): ICE handler gained 'connected' branch emitting RECONNECTED — a dedicated event meaning "ICE recovered." Correct.
- 9f86b40: Renamed RECONNECTED → CONNECTED, added a new CONNECTED emission in connect() after robotServiceClient is created. Did not remove the now-redundant ICE handler emission. Bug introduced.

Why this is safe:
- connect() already emits CONNECTED after robotServiceClient is created, covering both initial connection and reconnection via onDisconnect's backoff loop.
- StreamClient calls addStream() on CONNECTED, which requires robotServiceClient — the premature emission could cause silent failures.
- This fix allows downstream consumers (e.g. Svelte SDK) to trust CONNECTED as "client is usable" rather than having to ignore it and manage their own connection state.