### PR TITLE
feat: shouldRetryOnError

### DIFF
--- a/src/robot/__tests__/client.spec.ts
+++ b/src/robot/__tests__/client.spec.ts
@@ -802,6 +802,113 @@ describe('RobotClient', () => {
         // Assert
         expect(dialWebRTCMock).toHaveBeenCalledTimes(1);
       });
+
+      it('should retry non-retryable errors while shouldRetryOnError returns true', async () => {
+        // Arrange
+        vi.useFakeTimers();
+        let closeHandler: ((event: Event) => void) | undefined;
+        const shouldRetry = true;
+
+        const dcAddEventListener = vi.fn<[string, (event: unknown) => void]>(
+          (event: string, handler: (event: unknown) => void) => {
+            if (event === 'close') {
+              closeHandler = handler as (event: Event) => void;
+            }
+          }
+        );
+
+        const dataChannel = createMockDataChannel(
+          vi.fn(),
+          dcAddEventListener,
+          vi.fn(),
+          'open'
+        );
+
+        const dialWebRTCMock = vi
+          .mocked(rpcModule.dialWebRTC)
+          .mockResolvedValueOnce({
+            transport: createMockRobotServiceTransport(),
+            peerConnection: createMockPeerConnection(),
+            dataChannel,
+          })
+          .mockRejectedValue(errors.createNotFoundError());
+
+        const client = new RobotClient();
+
+        await client.dial({
+          ...baseDialConfig,
+          noReconnect: false,
+          reconnectMaxAttempts: 3,
+          shouldRetryOnError: () => shouldRetry,
+        });
+
+        // Reset mock call count after initial connection
+        dialWebRTCMock.mockClear();
+
+        // Act - trigger disconnect through data channel close event
+        expect(closeHandler).toBeDefined();
+        closeHandler!(new Event('close'));
+
+        // Wait for backoff attempts to complete
+        await vi.runAllTimersAsync();
+        await vi.runOnlyPendingTimersAsync();
+
+        // Assert - should retry all 3 attempts despite NotFound being non-retryable
+        expect(dialWebRTCMock).toHaveBeenCalledTimes(3);
+      });
+
+      it('should not retry non-retryable errors when shouldRetryOnError returns false', async () => {
+        // Arrange
+        vi.useFakeTimers();
+        let closeHandler: ((event: Event) => void) | undefined;
+        const shouldRetry = false;
+
+        const dcAddEventListener = vi.fn<[string, (event: unknown) => void]>(
+          (event: string, handler: (event: unknown) => void) => {
+            if (event === 'close') {
+              closeHandler = handler as (event: Event) => void;
+            }
+          }
+        );
+
+        const dataChannel = createMockDataChannel(
+          vi.fn(),
+          dcAddEventListener,
+          vi.fn(),
+          'open'
+        );
+
+        const dialWebRTCMock = vi
+          .mocked(rpcModule.dialWebRTC)
+          .mockResolvedValueOnce({
+            transport: createMockRobotServiceTransport(),
+            peerConnection: createMockPeerConnection(),
+            dataChannel,
+          })
+          .mockRejectedValue(errors.createNotFoundError());
+
+        const client = new RobotClient();
+
+        await client.dial({
+          ...baseDialConfig,
+          noReconnect: false,
+          reconnectMaxAttempts: 3,
+          shouldRetryOnError: () => shouldRetry,
+        });
+
+        // Reset mock call count after initial connection
+        dialWebRTCMock.mockClear();
+
+        // Act
+        expect(closeHandler).toBeDefined();
+        closeHandler!(new Event('close'));
+
+        await vi.runAllTimersAsync();
+        await vi.runOnlyPendingTimersAsync();
+
+        // Assert - should stop after 1 attempt, same as no callback
+        expect(dialWebRTCMock).toHaveBeenCalledTimes(1);
+      });
     });
 
     describe('reconnection - retryable errors', () => {

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -66,6 +66,14 @@ export interface DialWebRTCConf {
   /** @default Number.POSITIVE_INFINITY */
   reconnectMaxWait?: number;
   reconnectAbortSignal?: { abort: boolean };
+
+  /**
+   * Called when a non-retryable error is encountered during reconnection.
+   * Return true to treat the error as retryable. Does not override
+   * reconnectMaxAttempts — retries are still bounded by that limit.
+   */
+  shouldRetryOnError?: () => boolean;
+
   // WebRTC
   serviceHost?: string;
   signalingAddress: string;
@@ -97,6 +105,14 @@ export interface DialDirectConf {
   reconnectMaxAttempts?: number;
   reconnectMaxWait?: number;
   reconnectAbortSignal?: { abort: boolean };
+
+  /**
+   * Called when a non-retryable error is encountered during reconnection.
+   * Return true to treat the error as retryable. Does not override
+   * reconnectMaxAttempts — retries are still bounded by that limit.
+   */
+  shouldRetryOnError?: () => boolean;
+
   /**
    * Set timeout in milliseconds for dialing. Default is defined by
    * DIAL_TIMEOUT. A value of 0 disables the timeout.
@@ -124,12 +140,14 @@ interface WebRTCOptions {
   noReconnect?: boolean;
   reconnectMaxAttempts?: number;
   reconnectMaxWait?: number;
+  shouldRetryOnError?: () => boolean;
 }
 
 interface DirectOptions {
   noReconnect?: boolean;
   reconnectMaxAttempts?: number;
   reconnectMaxWait?: number;
+  shouldRetryOnError?: () => boolean;
 }
 
 interface SessionOptions {
@@ -452,6 +470,15 @@ export class RobotClient extends EventDispatcher implements Robot {
           return true;
         }
 
+        if (this.shouldRetryOnError?.()) {
+          // eslint-disable-next-line no-console
+          console.debug(
+            'Non-retryable error encountered, but shouldRetryOnError returned true',
+            error
+          );
+          return true;
+        }
+
         // eslint-disable-next-line no-console
         console.debug(
           'Non-retryable error encountered, stopping reconnection attempts',
@@ -505,6 +532,13 @@ export class RobotClient extends EventDispatcher implements Robot {
   private get reconnectMaxWait() {
     return (
       this.webrtcOptions.reconnectMaxWait ?? this.directOptions.reconnectMaxWait
+    );
+  }
+
+  private get shouldRetryOnError() {
+    return (
+      this.webrtcOptions.shouldRetryOnError ??
+      this.directOptions.shouldRetryOnError
     );
   }
 
@@ -663,6 +697,7 @@ export class RobotClient extends EventDispatcher implements Robot {
     this.webrtcOptions.noReconnect = conf.noReconnect;
     this.webrtcOptions.reconnectMaxWait = conf.reconnectMaxWait;
     this.webrtcOptions.reconnectMaxAttempts = conf.reconnectMaxAttempts;
+    this.webrtcOptions.shouldRetryOnError = conf.shouldRetryOnError;
 
     this.sessionOptions.disabled = conf.disableSessions ?? false;
 
@@ -705,6 +740,7 @@ export class RobotClient extends EventDispatcher implements Robot {
     this.directOptions.noReconnect = conf.noReconnect;
     this.directOptions.reconnectMaxWait = conf.reconnectMaxWait;
     this.directOptions.reconnectMaxAttempts = conf.reconnectMaxAttempts;
+    this.directOptions.shouldRetryOnError = conf.shouldRetryOnError;
 
     this.sessionOptions.disabled = conf.disableSessions ?? false;
 


### PR DESCRIPTION
Optional callback invoked during reconnection when a non-retryable error
is encountered (e.g. not_found, unauthenticated). Return true to treat
the error as retryable. Does not override reconnectMaxAttempts — retries
are still bounded by that limit.

This allows consumers (e.g. the Svelte SDK) to keep the TS SDK's
built-in exponential backoff retrying when they know the machine should
come back online.