### PR TITLE
AI update based on proto changes

### DIFF
--- a/src/app/app-client.spec.ts
+++ b/src/app/app-client.spec.ts
@@ -2092,6 +2092,7 @@ describe('AppClient tests', () => {
                 }),
               },
               fragmentIds: ['frag1', 'frag2'],
+              allowedOrgIds: ['org1', 'org2'],
             }),
         });
       });
@@ -2110,6 +2111,7 @@ describe('AppClient tests', () => {
         response.textCustomizations.machinePicker!.fields.subheading
       ).toEqual('Select your machine.');
       expect(response.fragmentIds).toEqual(['frag1', 'frag2']);
+      expect(response.allowedOrgIds).toEqual(['org1', 'org2']);
     });
   });
 });

--- a/src/app/app-client.ts
+++ b/src/app/app-client.ts
@@ -1277,7 +1277,7 @@ export class AppClient {
    * @param publicOnly Optional, deprecated boolean. Use fragmentVisibilities
    *   instead. If true then only public fragments will be listed. Defaults to
    *   true
-   * @param fragmentVisibilities Optional list of fragment visibilities to
+   * @param fragmentVisibility Optional list of fragment visibilities to
    *   include in returned list. An empty fragmentVisibilities list defaults to
    *   normal publicOnly behavior (discludes unlisted public fragments)
    *   Otherwise, fragment visibilities should contain one of the three
@@ -2247,7 +2247,7 @@ export class AppClient {
    *
    * @param publicNamespace The public namespace of the organization
    * @param name The name of the app
-   * @returns The branding information for the app
+   * @returns The branding information for the app, including its logo path, text customizations, fragment IDs, and a list of allowed organization IDs.
    */
   async getAppBranding(
     publicNamespace: string,


### PR DESCRIPTION
This is an AI-generated PR to update the SDK based on proto changes. The AI may make mistakes so review carefully.

**Summary of Changes:**
This change introduces the `allowedOrgIds` field to the `App` and `GetAppBrandingResponse` protobuf messages.

*   **Protobuf Updates:** Added `allowedOrgIds` to control which organizations can access an app. If the list is empty, all organizations are allowed.
*   **Client Updates:** Updated the `AppClient`'s `getAppBranding` method documentation and tests to include and verify the new `allowedOrgIds` field.