### PR TITLE
APP-14871: Report connection metadata after WebRTC dial

### DIFF
--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -24,7 +24,12 @@ import {
   Credentials as PBCredentials,
 } from '../gen/proto/rpc/v1/auth_pb';
 import { SignalingService } from '../gen/proto/rpc/webrtc/v1/signaling_connect';
-import { WebRTCConfig } from '../gen/proto/rpc/webrtc/v1/signaling_pb';
+import {
+  ICECandidateType,
+  ReportConnectionMetadataRequest,
+  SDKType,
+  WebRTCConfig,
+} from '../gen/proto/rpc/webrtc/v1/signaling_pb';
 import { newPeerConnectionForClient } from './peer';
 
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
@@ -599,6 +604,114 @@ const getOptionalWebRTCConfig = async (
   }
 };
 
+interface CandidateClassification {
+  type: ICECandidateType;
+  relayAddress: string;
+}
+
+// classifyCandidate maps a single ICE candidate to an ICE candidate type and, for relay
+// candidates, its relayed transport address.
+const classifyCandidate = (
+  stats: RTCStatsReport,
+  candidateId: string
+): CandidateClassification => {
+  const unspecified = {
+    type: ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED,
+    relayAddress: '',
+  };
+  if (!candidateId) {
+    return unspecified;
+  }
+  const cand = stats.get(candidateId) as
+    | { candidateType?: string; address?: string }
+    | undefined;
+  switch (cand?.candidateType) {
+    case 'host':
+      return {
+        type: ICECandidateType.ICE_CANDIDATE_TYPE_HOST,
+        relayAddress: '',
+      };
+    case 'srflx':
+    case 'prflx':
+      return {
+        type: ICECandidateType.ICE_CANDIDATE_TYPE_STUN,
+        relayAddress: '',
+      };
+    case 'relay':
+      return {
+        type: ICECandidateType.ICE_CANDIDATE_TYPE_RELAY,
+        relayAddress: cand.address ?? '',
+      };
+    default:
+      return unspecified;
+  }
+};
+
+// classifyConnection classifies each side of the connection: local is this SDK's candidate,
+// remote is the peer's. It uses the transport's authoritative selectedCandidatePairId; browsers
+// may flag multiple pairs as `nominated` (aggressive nomination), so the nominated+succeeded
+// scan is only a fallback for when selectedCandidatePairId is unavailable.
+const classifyConnection = async (
+  pc: RTCPeerConnection
+): Promise<{
+  local: CandidateClassification;
+  remote: CandidateClassification;
+}> => {
+  const stats = await pc.getStats();
+
+  let selectedPairId = '';
+  stats.forEach((stat) => {
+    if (stat.type === 'transport') {
+      const transport = stat as RTCTransportStats;
+      if (transport.selectedCandidatePairId) {
+        selectedPairId = transport.selectedCandidatePairId;
+      }
+    }
+  });
+
+  let pair = selectedPairId
+    ? (stats.get(selectedPairId) as RTCIceCandidatePairStats | undefined)
+    : undefined;
+  if (!pair) {
+    stats.forEach((stat) => {
+      if (stat.type === 'candidate-pair') {
+        const candidatePair = stat as RTCIceCandidatePairStats;
+        if (candidatePair.nominated && candidatePair.state === 'succeeded') {
+          pair = candidatePair;
+        }
+      }
+    });
+  }
+
+  return {
+    local: classifyCandidate(stats, pair?.localCandidateId ?? ''),
+    remote: classifyCandidate(stats, pair?.remoteCandidateId ?? ''),
+  };
+};
+
+// reportConnectionMetadata reports per-side WebRTC connection metadata to the signaling
+// server as a best-effort fire-and-forget operation.
+const reportConnectionMetadata = (
+  signalingClient: ReturnType<typeof createClient<typeof SignalingService>>,
+  callOpts: CallOptions,
+  pc: RTCPeerConnection
+): void => {
+  classifyConnection(pc)
+    .then(async ({ local, remote }) => {
+      await signalingClient.reportConnectionMetadata(
+        new ReportConnectionMetadataRequest({
+          local: { type: local.type, relayAddress: local.relayAddress },
+          remote: { type: remote.type, relayAddress: remote.relayAddress },
+          sdkType: SDKType.SDK_TYPE_TYPESCRIPT,
+        }),
+        { ...callOpts, timeoutMs: 5000 }
+      );
+    })
+    .catch(() => {
+      // best-effort, ignore errors
+    });
+};
+
 /**
  * DialWebRTC makes a connection to given host by signaling with the address
  * provided. A Promise is returned upon successful connection that contains a
@@ -683,6 +796,8 @@ export const dialWebRTC = async (
 
   try {
     const cc = await exchange.doExchange();
+
+    reportConnectionMetadata(signalingClient, callOpts, pc);
 
     if (
       dialOpts?.externalAuthAddress !== undefined &&


### PR DESCRIPTION
### Description

[APP-14871](https://viam.atlassian.net/browse/APP-14871) Track coturn usage

Calls `reportConnectionMetadata` on the signaling server after a WebRTC connection is successfully established, mirroring the Go implementation in viamrobotics/goutils#544.

- Adds `selectedICECandidateType` which inspects `RTCPeerConnection.getStats()` to find the nominated candidate pair and classify the connection as `host`, `stun`, `coturn_relay`, or `twilio_relay` (same logic as Go)
- Reports the ICE candidate type and `SDK_TYPE_TYPESCRIPT` 
- App side changes found [here](https://github.com/viamrobotics/app/pull/11316)

[APP-14871]: https://viam.atlassian.net/browse/APP-14871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ