### PR TITLE
APP-15653: Add reconnecting and reconnection failed state

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -10,6 +10,8 @@ export enum MachineConnectionEvent {
   DISCONNECTING = 'disconnecting',
   DISCONNECTED = 'disconnected',
   DIALING = 'dialing',
+  RECONNECTING = 'reconnecting',
+  RECONNECTION_FAILED = 'reconnection_failed',
 }
 
 export class EventDispatcher {

--- a/src/robot/__tests__/client.spec.ts
+++ b/src/robot/__tests__/client.spec.ts
@@ -596,6 +596,12 @@ describe('RobotClient', () => {
       return events;
     };
 
+    const setupConnectedEventCapture = (client: RobotClient) => {
+      const events: unknown[] = [];
+      client.on(MachineConnectionEvent.CONNECTED, (e) => events.push(e));
+      return events;
+    };
+
     describe('dial() - non-retryable errors', () => {
       it.each([
         { error: errors.createCanceledError(), description: 'Canceled' },
@@ -1053,6 +1059,7 @@ describe('RobotClient', () => {
         const reconnectingEvents = setupReconnectingEventCapture(client);
         const reconnectionFailedEvents =
           setupReconnectionFailedEventCapture(client);
+        const connectedEvents = setupConnectedEventCapture(client);
 
         // Act
         expect(closeHandler).toBeDefined();
@@ -1065,6 +1072,7 @@ describe('RobotClient', () => {
         // Assert
         expect(dialWebRTCMock).toHaveBeenCalledTimes(4);
         expect(reconnectingEvents).toHaveLength(1);
+        expect(connectedEvents).toHaveLength(1);
         expect(reconnectionFailedEvents).toHaveLength(0);
       });
     });

--- a/src/robot/__tests__/client.spec.ts
+++ b/src/robot/__tests__/client.spec.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RobotClient } from '../client';
+import { MachineConnectionEvent } from '../../events';
 import * as rpcModule from '../../rpc';
 import { createMockRobotServiceTransport } from './mocks/robot-service';
 import {
@@ -581,6 +582,20 @@ describe('RobotClient', () => {
   });
 
   describe('retry logic on error', () => {
+    const setupReconnectingEventCapture = (client: RobotClient) => {
+      const events: unknown[] = [];
+      client.on(MachineConnectionEvent.RECONNECTING, (e) => events.push(e));
+      return events;
+    };
+
+    const setupReconnectionFailedEventCapture = (client: RobotClient) => {
+      const events: unknown[] = [];
+      client.on(MachineConnectionEvent.RECONNECTION_FAILED, (e) =>
+        events.push(e)
+      );
+      return events;
+    };
+
     describe('dial() - non-retryable errors', () => {
       it.each([
         { error: errors.createCanceledError(), description: 'Canceled' },
@@ -791,6 +806,10 @@ describe('RobotClient', () => {
         // Reset mock call count after initial connection
         dialWebRTCMock.mockClear();
 
+        const reconnectingEvents = setupReconnectingEventCapture(client);
+        const reconnectionFailedEvents =
+          setupReconnectionFailedEventCapture(client);
+
         // Act - trigger disconnect through data channel close event
         expect(closeHandler).toBeDefined();
         closeHandler!(new Event('close'));
@@ -801,6 +820,8 @@ describe('RobotClient', () => {
 
         // Assert
         expect(dialWebRTCMock).toHaveBeenCalledTimes(1);
+        expect(reconnectingEvents).toHaveLength(1);
+        expect(reconnectionFailedEvents).toHaveLength(1);
       });
 
       it('should retry non-retryable errors while shouldRetryOnError returns true', async () => {
@@ -963,6 +984,10 @@ describe('RobotClient', () => {
           // Reset mock call count after initial connection
           dialWebRTCMock.mockClear();
 
+          const reconnectingEvents = setupReconnectingEventCapture(client);
+          const reconnectionFailedEvents =
+            setupReconnectionFailedEventCapture(client);
+
           // Act
           expect(closeHandler).toBeDefined();
           closeHandler!(new Event('close'));
@@ -973,6 +998,8 @@ describe('RobotClient', () => {
 
           // Assert
           expect(dialWebRTCMock).toHaveBeenCalledTimes(3);
+          expect(reconnectingEvents).toHaveLength(1);
+          expect(reconnectionFailedEvents).toHaveLength(1);
         }
       );
 
@@ -1023,6 +1050,10 @@ describe('RobotClient', () => {
         // Reset mock call count after initial connection
         dialWebRTCMock.mockClear();
 
+        const reconnectingEvents = setupReconnectingEventCapture(client);
+        const reconnectionFailedEvents =
+          setupReconnectionFailedEventCapture(client);
+
         // Act
         expect(closeHandler).toBeDefined();
         closeHandler!(new Event('close'));
@@ -1033,6 +1064,8 @@ describe('RobotClient', () => {
 
         // Assert
         expect(dialWebRTCMock).toHaveBeenCalledTimes(4);
+        expect(reconnectingEvents).toHaveLength(1);
+        expect(reconnectionFailedEvents).toHaveLength(0);
       });
     });
 

--- a/src/robot/__tests__/client.spec.ts
+++ b/src/robot/__tests__/client.spec.ts
@@ -584,21 +584,25 @@ describe('RobotClient', () => {
   describe('retry logic on error', () => {
     const setupReconnectingEventCapture = (client: RobotClient) => {
       const events: unknown[] = [];
-      client.on(MachineConnectionEvent.RECONNECTING, (e) => events.push(e));
+      client.on(MachineConnectionEvent.RECONNECTING, (event) =>
+        events.push(event)
+      );
       return events;
     };
 
     const setupReconnectionFailedEventCapture = (client: RobotClient) => {
       const events: unknown[] = [];
-      client.on(MachineConnectionEvent.RECONNECTION_FAILED, (e) =>
-        events.push(e)
+      client.on(MachineConnectionEvent.RECONNECTION_FAILED, (event) =>
+        events.push(event)
       );
       return events;
     };
 
     const setupConnectedEventCapture = (client: RobotClient) => {
       const events: unknown[] = [];
-      client.on(MachineConnectionEvent.CONNECTED, (e) => events.push(e));
+      client.on(MachineConnectionEvent.CONNECTED, (event) =>
+        events.push(event)
+      );
       return events;
     };
 

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -508,7 +508,7 @@ export class RobotClient extends EventDispatcher implements Robot {
         // eslint-disable-next-line no-console
         console.debug('Reconnected successfully!');
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         this.isReconnecting = false;
         // eslint-disable-next-line no-console
         console.debug(

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -352,6 +352,7 @@ export class RobotClient extends EventDispatcher implements Robot {
     | undefined;
 
   private currentRetryAttempt = 0;
+  private isReconnecting = false;
 
   private onICEConnectionStateChange?: () => void;
   private onDataChannelClose?: (event: Event) => void;
@@ -440,15 +441,18 @@ export class RobotClient extends EventDispatcher implements Robot {
   }
 
   private onDisconnect(event?: Event) {
-    this.emit(MachineConnectionEvent.DISCONNECTED, event ?? {});
-
     if (this.noReconnect !== undefined && this.noReconnect) {
+      this.emit(MachineConnectionEvent.DISCONNECTED, event ?? {});
       return;
     }
 
     if (this.closed) {
+      this.emit(MachineConnectionEvent.DISCONNECTED, event ?? {});
       return;
     }
+
+    this.isReconnecting = true;
+    this.emit(MachineConnectionEvent.RECONNECTING, { event: event ?? {} });
 
     // eslint-disable-next-line no-console
     console.debug('Connection closed, will try to reconnect');
@@ -500,21 +504,25 @@ export class RobotClient extends EventDispatcher implements Robot {
 
     void backOff(async () => this.connect(), backOffOpts)
       .then(() => {
+        this.isReconnecting = false;
         // eslint-disable-next-line no-console
         console.debug('Reconnected successfully!');
       })
       .catch((error) => {
-        if (
-          this.reconnectMaxAttempts !== undefined &&
-          this.currentRetryAttempt >= this.reconnectMaxAttempts
         ) {
           // eslint-disable-next-line no-console
           console.debug(`Reached max attempts: ${this.reconnectMaxAttempts}`);
           return;
-        }
-
+        this.isReconnecting = false;
         // eslint-disable-next-line no-console
-        console.error(error);
+        console.debug(
+          `Reconnection failed after ${this.currentRetryAttempt} attempt(s)`,
+          error
+        );
+        this.emit(MachineConnectionEvent.RECONNECTION_FAILED, {
+          error,
+          attempts: this.currentRetryAttempt,
+        });
       });
   }
 
@@ -1003,7 +1011,9 @@ export class RobotClient extends EventDispatcher implements Robot {
     dialTimeoutMs,
     extraHeaders,
   }: ConnectOptions = {}) {
-    this.emit(MachineConnectionEvent.CONNECTING, {});
+    if (!this.isReconnecting) {
+      this.emit(MachineConnectionEvent.CONNECTING, {});
+    }
     this.closed = false;
 
     if (this.connecting) {
@@ -1164,7 +1174,9 @@ export class RobotClient extends EventDispatcher implements Robot {
       // Need to catch the error to properly emit disconnect but
       // also throw the error so reconnect backoff keeps retrying.
       // TODO(ethanlook): clean this up
-      this.emit(MachineConnectionEvent.DISCONNECTED, {});
+      if (!this.isReconnecting) {
+        this.emit(MachineConnectionEvent.DISCONNECTED, {});
+      }
       throw error;
     } finally {
       this.connectResolve?.();

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -509,10 +509,6 @@ export class RobotClient extends EventDispatcher implements Robot {
         console.debug('Reconnected successfully!');
       })
       .catch((error) => {
-        ) {
-          // eslint-disable-next-line no-console
-          console.debug(`Reached max attempts: ${this.reconnectMaxAttempts}`);
-          return;
         this.isReconnecting = false;
         // eslint-disable-next-line no-console
         console.debug(


### PR DESCRIPTION
Proposal:
https://docs.google.com/document/d/1jwOwAHAoSIjSlPAYl-_H8yo2qBnoHr0uPItEnDLs4ck/edit?tab=t.0#heading=h.hloa3ivfpho6

Basically, instead of switching between connected and disconnected when trying to reconnect, it'll just emit one state during this entire time- reconnecting. Moreover, when this fails (retry attempts maxed out or it hits a non-retryable error) it will emit reconnection failed. 

This will not be merged until all parts are ready, but putting it up for feedback now