### PR TITLE
[APP-15934] Add signalingInsecure Dial Option

### DIFF
--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -177,6 +177,13 @@ interface WebRTCOptions {
   reconnectMaxAttempts?: number;
   reconnectMaxWait?: number;
   shouldRetryOnError?: () => boolean;
+  forceRelay?: boolean;
+  forceP2P?: boolean;
+  turnUri?: string;
+  turnScheme?: 'turn' | 'turns';
+  turnTransport?: 'tcp' | 'udp';
+  turnPort?: number;
+  signalingInsecure?: boolean;
 }
 
 interface DirectOptions {
@@ -1103,6 +1110,13 @@ export class RobotClient extends EventDispatcher implements Robot {
         webrtcOptions: {
           disableTrickleICE: false,
           rtcConfig: this.webrtcOptions.rtcConfig,
+          forceRelay: this.webrtcOptions.forceRelay,
+          forceP2P: this.webrtcOptions.forceP2P,
+          turnUri: this.webrtcOptions.turnUri,
+          turnScheme: this.webrtcOptions.turnScheme,
+          turnTransport: this.webrtcOptions.turnTransport,
+          turnPort: this.webrtcOptions.turnPort,
+          signalingInsecure: this.webrtcOptions.signalingInsecure,
         },
         dialTimeoutMs: dialTimeoutMs ?? dialTimeout ?? DIAL_TIMEOUT,
         extraHeaders: mergedHeaders,

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -111,6 +111,12 @@ export interface DialWebRTCConf {
   turnPort?: number;
 
   /**
+   * When true, the connection to the signaling server is made over plain HTTP
+   * (no TLS). Use this when connecting to a robot running with `no_tls: true`.
+   */
+  signalingInsecure?: boolean;
+
+  /**
    * Set timeout in milliseconds for dialing. Default is defined by
    * DIAL_TIMEOUT. A value of 0 disables the timeout.
    *
@@ -171,12 +177,6 @@ interface WebRTCOptions {
   reconnectMaxAttempts?: number;
   reconnectMaxWait?: number;
   shouldRetryOnError?: () => boolean;
-  forceRelay?: boolean;
-  forceP2P?: boolean;
-  turnUri?: string;
-  turnScheme?: 'turn' | 'turns';
-  turnTransport?: 'tcp' | 'udp';
-  turnPort?: number;
 }
 
 interface DirectOptions {
@@ -740,6 +740,7 @@ export class RobotClient extends EventDispatcher implements Robot {
     this.webrtcOptions.turnScheme = conf.turnScheme;
     this.webrtcOptions.turnTransport = conf.turnTransport;
     this.webrtcOptions.turnPort = conf.turnPort;
+    this.webrtcOptions.signalingInsecure = conf.signalingInsecure;
 
     this.sessionOptions.disabled = conf.disableSessions ?? false;
 
@@ -1102,12 +1103,6 @@ export class RobotClient extends EventDispatcher implements Robot {
         webrtcOptions: {
           disableTrickleICE: false,
           rtcConfig: this.webrtcOptions.rtcConfig,
-          forceRelay: this.webrtcOptions.forceRelay,
-          forceP2P: this.webrtcOptions.forceP2P,
-          turnUri: this.webrtcOptions.turnUri,
-          turnScheme: this.webrtcOptions.turnScheme,
-          turnTransport: this.webrtcOptions.turnTransport,
-          turnPort: this.webrtcOptions.turnPort,
         },
         dialTimeoutMs: dialTimeoutMs ?? dialTimeout ?? DIAL_TIMEOUT,
         extraHeaders: mergedHeaders,

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -98,7 +98,7 @@ export interface DialWebRTCOptions {
 
   // `additionalSDPValues` is a collection of additional SDP values that we want to pass into the connection's call request.
   additionalSdpFields?: Record<string, string | number>;
-  
+
   /**
    * When true, sets ICE transport policy to relay-only so only TURN candidates
    * are used. Useful for testing relay connectivity through a TURN server.

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -98,7 +98,7 @@ export interface DialWebRTCOptions {
 
   // `additionalSDPValues` is a collection of additional SDP values that we want to pass into the connection's call request.
   additionalSdpFields?: Record<string, string | number>;
-
+  
   /**
    * When true, sets ICE transport policy to relay-only so only TURN candidates
    * are used. Useful for testing relay connectivity through a TURN server.
@@ -128,6 +128,12 @@ export interface DialWebRTCOptions {
 
   /** Overrides the port of the matched TURN URI. */
   turnPort?: number;
+
+  /**
+   * When true, the connection to the signaling server is made over plain HTTP
+   * (no TLS). Use this when connecting to a robot running with `no_tls: true`.
+   */
+  signalingInsecure?: boolean;
 }
 
 export type TransportFactory = (
@@ -476,7 +482,13 @@ export const dialWebRTC = async (
   dialOpts?: DialOptions,
   transportCredentialsInclude = false
 ): Promise<WebRTCConnection> => {
-  const usableSignalingAddress = signalingAddress.replace(/\/$/u, '');
+  let usableSignalingAddress = signalingAddress.replace(/\/$/u, '');
+  if (dialOpts?.webrtcOptions?.signalingInsecure) {
+    // TLS for the signaling connection is determined by the URL scheme passed
+    // as baseUrl to the gRPC-web transport. Strip any existing http/https scheme
+    // and force http:// so the signaling server is contacted without TLS.
+    usableSignalingAddress = `http://${usableSignalingAddress.replace(/^https?:\/\//u, '')}`;
+  }
   validateDialOptions(dialOpts);
 
   /**


### PR DESCRIPTION
## Description

[APP-15934](https://viam.atlassian.net/browse/APP-15934) Local SOW app mode does not work on linux

When there is no internet connectivity at the factory, robots must run in http/no TLS mode locally. The SOW app is a typescript client and in order to connect to the sanding robots, it must dial with them the `goutils` equivalent of the `SignalingInsecure: true` dial option. This PR adds the equivalent `signalingInsecure` dial option to the typescript SDK to support connecting to robots running without TLS. 

* Adds `signalingInsecure?: boolean` to `DialWebRTCOptions`: when true, rewrites the signaling server address to use `http://` before it is passed to `dialDirect` as the `baseUrl`. In the TypeScript SDK, TLS for a connection is determined entirely by the URL scheme, so this is the equivalent of Go's `SignalingInsecure` flag.
    * The rewrite strips any existing `http://` or `https://` scheme and forces `http://`, handling bare `host:port` addresses, addresses already prefixed with `http://`, and addresses prefixed with `https://`.
* Threads `signalingInsecure` through the `RobotClient` stack: `DialWebRTCConf` → internal `WebRTCOptions` → `DialOptions.webrtcOptions` in `connect()`.

## Testing
- [x] Verify a TypeScript client can connect to a robot running with `no_tls: true` using `signalingInsecure: true`
- [x] Verify a TypeScript client connecting to a normal TLS robot is unaffected

[APP-15934]: https://viam.atlassian.net/browse/APP-15934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ