### PR TITLE
RSDK-10883 - add structured debug logging for connection and gRPC events

### DIFF
--- a/src/debug.spec.ts
+++ b/src/debug.spec.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createConsoleLogWriter,
+  isDebugLogEnabled,
+  setDebugLogWriter,
+  writeDebugLog,
+} from './debug';
+
+describe('debug logging', () => {
+  afterEach(() => {
+    setDebugLogWriter(undefined);
+    vi.restoreAllMocks();
+  });
+
+  describe('writeDebugLog', () => {
+    it('does nothing when no writer is set', () => {
+      const writer = vi.fn();
+      writeDebugLog('test_event', { foo: 'bar' });
+      expect(writer).not.toHaveBeenCalled();
+    });
+
+    it('calls the writer with event, fields, and an ISO 8601 timestamp', () => {
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+
+      writeDebugLog('test_event', { connectionId: 'abc', extra: 123 });
+
+      expect(writer).toHaveBeenCalledOnce();
+      const [entry] = writer.mock.calls[0]!;
+      expect(entry.event).toBe('test_event');
+      expect(entry.connectionId).toBe('abc');
+      expect(entry.extra).toBe(123);
+      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+
+    it('stops calling the writer after it is cleared', () => {
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      writeDebugLog('first');
+      setDebugLogWriter(undefined);
+      writeDebugLog('second');
+      expect(writer).toHaveBeenCalledOnce();
+    });
+
+    it('works with no extra fields', () => {
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      writeDebugLog('bare_event');
+      const [entry] = writer.mock.calls[0]!;
+      expect(entry.event).toBe('bare_event');
+      expect(entry.timestamp).toBeDefined();
+    });
+  });
+
+  describe('isDebugLogEnabled', () => {
+    it('returns false when no writer is set', () => {
+      expect(isDebugLogEnabled()).toBe(false);
+    });
+
+    it('returns true when a writer is set', () => {
+      setDebugLogWriter(vi.fn());
+      expect(isDebugLogEnabled()).toBe(true);
+    });
+
+    it('returns false after the writer is cleared', () => {
+      setDebugLogWriter(vi.fn());
+      setDebugLogWriter(undefined);
+      expect(isDebugLogEnabled()).toBe(false);
+    });
+  });
+
+  describe('createConsoleLogWriter', () => {
+    it('calls console.debug with [viam-sdk] prefix and JSON-stringified entry', () => {
+      const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      const writer = createConsoleLogWriter();
+      const entry = { timestamp: '2024-01-01T00:00:00.000Z', event: 'test' };
+
+      writer(entry);
+
+      expect(spy).toHaveBeenCalledWith('[viam-sdk]', JSON.stringify(entry));
+    });
+  });
+});

--- a/src/debug.spec.ts
+++ b/src/debug.spec.ts
@@ -6,23 +6,25 @@ import {
   isDebugLogEnabled,
   setDebugLogWriter,
   writeDebugLog,
+  type DebugLogEntry,
 } from './debug';
 
 describe('debug logging', () => {
   afterEach(() => {
     setDebugLogWriter(undefined);
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('writeDebugLog', () => {
     it('does nothing when no writer is set', () => {
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       writeDebugLog('test_event', { foo: 'bar' });
       expect(writer).not.toHaveBeenCalled();
     });
 
     it('calls the writer with event, fields, and an ISO 8601 timestamp', () => {
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
 
       writeDebugLog('test_event', { connectionId: 'abc', extra: 123 });
@@ -32,11 +34,11 @@ describe('debug logging', () => {
       expect(entry.event).toBe('test_event');
       expect(entry.connectionId).toBe('abc');
       expect(entry.extra).toBe(123);
-      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/u);
     });
 
     it('stops calling the writer after it is cleared', () => {
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       writeDebugLog('first');
       setDebugLogWriter(undefined);
@@ -45,7 +47,7 @@ describe('debug logging', () => {
     });
 
     it('works with no extra fields', () => {
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       writeDebugLog('bare_event');
       const [entry] = writer.mock.calls[0]!;
@@ -73,13 +75,14 @@ describe('debug logging', () => {
 
   describe('createConsoleLogWriter', () => {
     it('calls console.debug with [viam-sdk] prefix and JSON-stringified entry', () => {
-      const spy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+      const debugSpy = vi.fn<[string, string]>();
+      vi.stubGlobal('console', { ...console, debug: debugSpy });
       const writer = createConsoleLogWriter();
       const entry = { timestamp: '2024-01-01T00:00:00.000Z', event: 'test' };
 
       writer(entry);
 
-      expect(spy).toHaveBeenCalledWith('[viam-sdk]', JSON.stringify(entry));
+      expect(debugSpy).toHaveBeenCalledWith('[viam-sdk]', JSON.stringify(entry));
     });
   });
 });

--- a/src/debug.spec.ts
+++ b/src/debug.spec.ts
@@ -23,7 +23,7 @@ describe('debug logging', () => {
       expect(writer).not.toHaveBeenCalled();
     });
 
-    it('calls the writer with event, fields, and an ISO 8601 timestamp', () => {
+    it('calls the writer with event, fields, and a Date timestamp', () => {
       const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
 
@@ -34,7 +34,7 @@ describe('debug logging', () => {
       expect(entry.event).toBe('test_event');
       expect(entry.connectionId).toBe('abc');
       expect(entry.extra).toBe(123);
-      expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/u);
+      expect(entry.timestamp).toBeInstanceOf(Date);
     });
 
     it('stops calling the writer after it is cleared', () => {
@@ -78,7 +78,7 @@ describe('debug logging', () => {
       const debugSpy = vi.fn<[string, string]>();
       vi.stubGlobal('console', { ...console, debug: debugSpy });
       const writer = createConsoleLogWriter();
-      const entry = { timestamp: '2024-01-01T00:00:00.000Z', event: 'test' };
+      const entry = { timestamp: new Date('2024-01-01T00:00:00.000Z'), event: 'test' };
 
       writer(entry);
 

--- a/src/debug.spec.ts
+++ b/src/debug.spec.ts
@@ -78,7 +78,10 @@ describe('debug logging', () => {
       const debugSpy = vi.fn<[string, string]>();
       vi.stubGlobal('console', { ...console, debug: debugSpy });
       const writer = createConsoleLogWriter();
-      const entry = { timestamp: new Date('2024-01-01T00:00:00.000Z'), event: 'test' };
+      const entry = {
+        timestamp: new Date('2024-01-01T00:00:00.000Z'),
+        event: 'test',
+      };
 
       writer(entry);
 

--- a/src/debug.spec.ts
+++ b/src/debug.spec.ts
@@ -82,7 +82,10 @@ describe('debug logging', () => {
 
       writer(entry);
 
-      expect(debugSpy).toHaveBeenCalledWith('[viam-sdk]', JSON.stringify(entry));
+      expect(debugSpy).toHaveBeenCalledWith(
+        '[viam-sdk]',
+        JSON.stringify(entry)
+      );
     });
   });
 });

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -80,7 +80,9 @@ export const writeDebugLog = (
   event: string,
   fields: Record<string, unknown> = {}
 ): void => {
-  if (!currentWriter) return;
+  if (!currentWriter) {
+    return;
+  }
   currentWriter({
     timestamp: new Date().toISOString(),
     event,
@@ -92,7 +94,9 @@ export const writeDebugLog = (
  * Returns a {@link DebugLogWriter} that prints each entry to the console as a
  * JSON string, prefixed with `[viam-sdk]`.
  */
-export const createConsoleLogWriter = (): DebugLogWriter => (entry) => {
+const consoleLogWriter: DebugLogWriter = (entry) => {
   // eslint-disable-next-line no-console
   console.debug('[viam-sdk]', JSON.stringify(entry));
 };
+
+export const createConsoleLogWriter = (): DebugLogWriter => consoleLogWriter;

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -4,20 +4,28 @@
  * Enable debug logging by calling {@link setDebugLogWriter} before connecting.
  *
  * @example Log connection events to the browser console:
+ *
  * ```ts
- * import { setDebugLogWriter, createConsoleLogWriter } from '@viamrobotics/sdk';
+ * import {
+ *   setDebugLogWriter,
+ *   createConsoleLogWriter,
+ * } from '@viamrobotics/sdk';
  * setDebugLogWriter(createConsoleLogWriter());
  * ```
  *
  * @example Write log entries to a file in Node.js:
+ *
  * ```ts
  * import fs from 'node:fs';
  * import { setDebugLogWriter } from '@viamrobotics/sdk';
  * const logFile = fs.createWriteStream('viam-debug.log', { flags: 'a' });
- * setDebugLogWriter((entry) => logFile.write(JSON.stringify(entry) + '\n'));
+ * setDebugLogWriter((entry) =>
+ *   logFile.write(JSON.stringify(entry) + '\n')
+ * );
  * ```
  *
  * Logged events:
+ *
  * - `dial_started` — a new connection attempt began
  * - `dial_success` — the connection was established; includes `connectionId`
  * - `dial_failed` — the connection attempt failed
@@ -32,9 +40,8 @@ export interface DebugLogEntry {
   /** ISO 8601 timestamp of when the event occurred. */
   timestamp: string;
   /**
-   * The type of event. One of:
-   * `dial_started`, `dial_success`, `dial_failed`, `grpc_request`,
-   * `grpc_response`, `client_closed`, `ice_disconnected`.
+   * The type of event. One of: `dial_started`, `dial_success`, `dial_failed`,
+   * `grpc_request`, `grpc_response`, `client_closed`, `ice_disconnected`.
    */
   event: string;
   /** The ID of the connection this event relates to, when applicable. */
@@ -52,8 +59,12 @@ let currentWriter: DebugLogWriter | undefined;
  * Pass `undefined` to disable debug logging.
  *
  * @example
+ *
  * ```ts
- * import { setDebugLogWriter, createConsoleLogWriter } from '@viamrobotics/sdk';
+ * import {
+ *   setDebugLogWriter,
+ *   createConsoleLogWriter,
+ * } from '@viamrobotics/sdk';
  * // Enable:
  * setDebugLogWriter(createConsoleLogWriter());
  * // Disable:

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,98 @@
+/**
+ * Structured debug logging for the Viam TypeScript SDK.
+ *
+ * Enable debug logging by calling {@link setDebugLogWriter} before connecting.
+ *
+ * @example Log connection events to the browser console:
+ * ```ts
+ * import { setDebugLogWriter, createConsoleLogWriter } from '@viamrobotics/sdk';
+ * setDebugLogWriter(createConsoleLogWriter());
+ * ```
+ *
+ * @example Write log entries to a file in Node.js:
+ * ```ts
+ * import fs from 'node:fs';
+ * import { setDebugLogWriter } from '@viamrobotics/sdk';
+ * const logFile = fs.createWriteStream('viam-debug.log', { flags: 'a' });
+ * setDebugLogWriter((entry) => logFile.write(JSON.stringify(entry) + '\n'));
+ * ```
+ *
+ * Logged events:
+ * - `dial_started` — a new connection attempt began
+ * - `dial_success` — the connection was established; includes `connectionId`
+ * - `dial_failed` — the connection attempt failed
+ * - `grpc_request` — a gRPC request was sent through a connection
+ * - `grpc_response` — a gRPC response was received (includes `error` on failure)
+ * - `client_closed` — the client was explicitly closed
+ * - `ice_disconnected` — the WebRTC ICE connection entered the Disconnected state
+ */
+
+/** A single structured debug log entry emitted by the Viam SDK. */
+export interface DebugLogEntry {
+  /** ISO 8601 timestamp of when the event occurred. */
+  timestamp: string;
+  /**
+   * The type of event. One of:
+   * `dial_started`, `dial_success`, `dial_failed`, `grpc_request`,
+   * `grpc_response`, `client_closed`, `ice_disconnected`.
+   */
+  event: string;
+  /** The ID of the connection this event relates to, when applicable. */
+  connectionId?: string;
+  [key: string]: unknown;
+}
+
+/** A function that receives structured debug log entries from the SDK. */
+export type DebugLogWriter = (entry: DebugLogEntry) => void;
+
+let currentWriter: DebugLogWriter | undefined;
+
+/**
+ * Set a writer function to receive structured debug log entries from the SDK.
+ * Pass `undefined` to disable debug logging.
+ *
+ * @example
+ * ```ts
+ * import { setDebugLogWriter, createConsoleLogWriter } from '@viamrobotics/sdk';
+ * // Enable:
+ * setDebugLogWriter(createConsoleLogWriter());
+ * // Disable:
+ * setDebugLogWriter(undefined);
+ * ```
+ */
+export const setDebugLogWriter = (writer: DebugLogWriter | undefined): void => {
+  currentWriter = writer;
+};
+
+/**
+ * Returns true if a debug log writer is currently set.
+ *
+ * @internal
+ */
+export const isDebugLogEnabled = (): boolean => currentWriter !== undefined;
+
+/**
+ * Write a debug log entry if a writer is currently set.
+ *
+ * @internal
+ */
+export const writeDebugLog = (
+  event: string,
+  fields: Record<string, unknown> = {}
+): void => {
+  if (!currentWriter) return;
+  currentWriter({
+    timestamp: new Date().toISOString(),
+    event,
+    ...fields,
+  });
+};
+
+/**
+ * Returns a {@link DebugLogWriter} that prints each entry to the console as a
+ * JSON string, prefixed with `[viam-sdk]`.
+ */
+export const createConsoleLogWriter = (): DebugLogWriter => (entry) => {
+  // eslint-disable-next-line no-console
+  console.debug('[viam-sdk]', JSON.stringify(entry));
+};

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -37,8 +37,8 @@
 
 /** A single structured debug log entry emitted by the Viam SDK. */
 export interface DebugLogEntry {
-  /** ISO 8601 timestamp of when the event occurred. */
-  timestamp: string;
+  /** The time at which the event occurred. */
+  timestamp: Date;
   /**
    * The type of event. One of: `dial_started`, `dial_success`, `dial_failed`,
    * `grpc_request`, `grpc_response`, `client_closed`, `ice_disconnected`.
@@ -95,7 +95,7 @@ export const writeDebugLog = (
     return;
   }
   currentWriter({
-    timestamp: new Date().toISOString(),
+    timestamp: new Date(),
     event,
     ...fields,
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -461,4 +461,11 @@ export {
   getStatusFromClient,
 } from './utils';
 
+export {
+  createConsoleLogWriter,
+  setDebugLogWriter,
+  type DebugLogEntry,
+  type DebugLogWriter,
+} from './debug';
+
 export { MachineConnectionEvent } from './events';

--- a/src/robot/__tests__/client.spec.ts
+++ b/src/robot/__tests__/client.spec.ts
@@ -1178,7 +1178,7 @@ describe('RobotClient', () => {
         .map(([entry]) => entry)
         .filter((entry) => entry.event === 'dial_started');
       expect(startedEntries.length).toBeGreaterThanOrEqual(1);
-      const [entry] = startedEntries;
+      const entry = startedEntries[0]!;
       expect(entry.connectionId).toBeDefined();
       expect(entry.host).toBeDefined();
       expect(entry.method).toBeDefined();
@@ -1212,10 +1212,12 @@ describe('RobotClient', () => {
 
       // Assert
       const entries = writer.mock.calls.map(([entry]) => entry);
-      const startedId = entries.find((entry) => entry.event === 'dial_started')
-        ?.connectionId;
-      const successId = entries.find((entry) => entry.event === 'dial_success')
-        ?.connectionId;
+      const startedId = entries.find(
+        (entry) => entry.event === 'dial_started'
+      )?.connectionId;
+      const successId = entries.find(
+        (entry) => entry.event === 'dial_success'
+      )?.connectionId;
       expect(startedId).toBeDefined();
       expect(startedId).toBe(successId);
     });
@@ -1274,10 +1276,12 @@ describe('RobotClient', () => {
 
       // Assert
       const entries = writer.mock.calls.map(([entry]) => entry);
-      const successId = entries.find((entry) => entry.event === 'dial_success')
-        ?.connectionId;
-      const closedId = entries.find((entry) => entry.event === 'client_closed')
-        ?.connectionId;
+      const successId = entries.find(
+        (entry) => entry.event === 'dial_success'
+      )?.connectionId;
+      const closedId = entries.find(
+        (entry) => entry.event === 'client_closed'
+      )?.connectionId;
       expect(successId).toBeDefined();
       expect(closedId).toBe(successId);
     });

--- a/src/robot/__tests__/client.spec.ts
+++ b/src/robot/__tests__/client.spec.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RobotClient } from '../client';
 import { MachineConnectionEvent } from '../../events';
 import * as rpcModule from '../../rpc';
-import { setDebugLogWriter } from '../../debug';
+import { setDebugLogWriter, type DebugLogEntry } from '../../debug';
 import { createMockRobotServiceTransport } from './mocks/robot-service';
 import {
   TEST_HOST,
@@ -1166,7 +1166,7 @@ describe('RobotClient', () => {
 
     it('logs dial_started when a connection attempt begins', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const client = setupClientMocks();
 
@@ -1186,7 +1186,7 @@ describe('RobotClient', () => {
 
     it('logs dial_success after a successful connection', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const client = setupClientMocks();
 
@@ -1203,7 +1203,7 @@ describe('RobotClient', () => {
 
     it('dial_started and dial_success share the same connectionId', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const client = setupClientMocks();
 
@@ -1212,9 +1212,9 @@ describe('RobotClient', () => {
 
       // Assert
       const entries = writer.mock.calls.map(([entry]) => entry);
-      const startedId = entries.find((e) => e.event === 'dial_started')
+      const startedId = entries.find((entry) => entry.event === 'dial_started')
         ?.connectionId;
-      const successId = entries.find((e) => e.event === 'dial_success')
+      const successId = entries.find((entry) => entry.event === 'dial_success')
         ?.connectionId;
       expect(startedId).toBeDefined();
       expect(startedId).toBe(successId);
@@ -1222,7 +1222,7 @@ describe('RobotClient', () => {
 
     it('logs dial_failed when a connection attempt fails', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const client = new RobotClient();
       vi.mocked(rpcModule.dialWebRTC).mockRejectedValue(
@@ -1247,7 +1247,7 @@ describe('RobotClient', () => {
 
     it('logs client_closed when disconnect is called', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const client = setupClientMocks();
       await client.dial({ ...baseDialConfig, noReconnect: true });
@@ -1264,7 +1264,7 @@ describe('RobotClient', () => {
 
     it('logs client_closed with the connectionId from the prior connection', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const client = setupClientMocks();
       await client.dial({ ...baseDialConfig, noReconnect: true });
@@ -1274,9 +1274,9 @@ describe('RobotClient', () => {
 
       // Assert
       const entries = writer.mock.calls.map(([entry]) => entry);
-      const successId = entries.find((e) => e.event === 'dial_success')
+      const successId = entries.find((entry) => entry.event === 'dial_success')
         ?.connectionId;
-      const closedId = entries.find((e) => e.event === 'client_closed')
+      const closedId = entries.find((entry) => entry.event === 'client_closed')
         ?.connectionId;
       expect(successId).toBeDefined();
       expect(closedId).toBe(successId);
@@ -1284,7 +1284,7 @@ describe('RobotClient', () => {
 
     it('logs client_closed with undefined connectionId when disconnecting before any connection', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const client = new RobotClient();
 
@@ -1301,7 +1301,7 @@ describe('RobotClient', () => {
 
     it('logs ice_disconnected when the ICE connection enters the disconnected state', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const mocks = setupEventListenerMocks();
       await mocks.client.dial({ ...baseDialConfig, noReconnect: true });

--- a/src/robot/__tests__/client.spec.ts
+++ b/src/robot/__tests__/client.spec.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { RobotClient } from '../client';
 import { MachineConnectionEvent } from '../../events';
 import * as rpcModule from '../../rpc';
+import { setDebugLogWriter } from '../../debug';
 import { createMockRobotServiceTransport } from './mocks/robot-service';
 import {
   TEST_HOST,
@@ -73,6 +74,7 @@ const setupEventListenerMocks = () => {
 
   return {
     client,
+    peerConnection,
     pcAddEventListener,
     pcRemoveEventListener,
     dcAddEventListener,
@@ -1154,6 +1156,173 @@ describe('RobotClient', () => {
         expect(dialWebRTCMock).toHaveBeenCalledTimes(maxAttempts);
         expect(dialDirectMock).toHaveBeenCalledTimes(maxAttempts);
       });
+    });
+  });
+
+  describe('debug logging', () => {
+    afterEach(() => {
+      setDebugLogWriter(undefined);
+    });
+
+    it('logs dial_started when a connection attempt begins', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const client = setupClientMocks();
+
+      // Act
+      await client.dial({ ...baseDialConfig, noReconnect: true });
+
+      // Assert
+      const startedEntries = writer.mock.calls
+        .map(([entry]) => entry)
+        .filter((entry) => entry.event === 'dial_started');
+      expect(startedEntries.length).toBeGreaterThanOrEqual(1);
+      const [entry] = startedEntries;
+      expect(entry.connectionId).toBeDefined();
+      expect(entry.host).toBeDefined();
+      expect(entry.method).toBeDefined();
+    });
+
+    it('logs dial_success after a successful connection', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const client = setupClientMocks();
+
+      // Act
+      await client.dial({ ...baseDialConfig, noReconnect: true });
+
+      // Assert
+      const successEntries = writer.mock.calls
+        .map(([entry]) => entry)
+        .filter((entry) => entry.event === 'dial_success');
+      expect(successEntries).toHaveLength(1);
+      expect(successEntries[0]!.connectionId).toBeDefined();
+    });
+
+    it('dial_started and dial_success share the same connectionId', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const client = setupClientMocks();
+
+      // Act
+      await client.dial({ ...baseDialConfig, noReconnect: true });
+
+      // Assert
+      const entries = writer.mock.calls.map(([entry]) => entry);
+      const startedId = entries.find((e) => e.event === 'dial_started')
+        ?.connectionId;
+      const successId = entries.find((e) => e.event === 'dial_success')
+        ?.connectionId;
+      expect(startedId).toBeDefined();
+      expect(startedId).toBe(successId);
+    });
+
+    it('logs dial_failed when a connection attempt fails', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const client = new RobotClient();
+      vi.mocked(rpcModule.dialWebRTC).mockRejectedValue(
+        new Error('WebRTC failed')
+      );
+
+      // Act — baseDialConfig uses TEST_HOST (non-local), so gRPC fallback also fails
+      try {
+        await client.dial({ ...baseDialConfig, noReconnect: true });
+      } catch {
+        // Expected to throw
+      }
+
+      // Assert
+      const failedEntries = writer.mock.calls
+        .map(([entry]) => entry)
+        .filter((entry) => entry.event === 'dial_failed');
+      expect(failedEntries.length).toBeGreaterThanOrEqual(1);
+      expect(failedEntries[0]!.error).toBeDefined();
+      expect(failedEntries[0]!.connectionId).toBeDefined();
+    });
+
+    it('logs client_closed when disconnect is called', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const client = setupClientMocks();
+      await client.dial({ ...baseDialConfig, noReconnect: true });
+
+      // Act
+      await client.disconnect();
+
+      // Assert
+      const closedEntries = writer.mock.calls
+        .map(([entry]) => entry)
+        .filter((entry) => entry.event === 'client_closed');
+      expect(closedEntries).toHaveLength(1);
+    });
+
+    it('logs client_closed with the connectionId from the prior connection', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const client = setupClientMocks();
+      await client.dial({ ...baseDialConfig, noReconnect: true });
+
+      // Act
+      await client.disconnect();
+
+      // Assert
+      const entries = writer.mock.calls.map(([entry]) => entry);
+      const successId = entries.find((e) => e.event === 'dial_success')
+        ?.connectionId;
+      const closedId = entries.find((e) => e.event === 'client_closed')
+        ?.connectionId;
+      expect(successId).toBeDefined();
+      expect(closedId).toBe(successId);
+    });
+
+    it('logs client_closed with undefined connectionId when disconnecting before any connection', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const client = new RobotClient();
+
+      // Act
+      await client.disconnect();
+
+      // Assert
+      const closedEntries = writer.mock.calls
+        .map(([entry]) => entry)
+        .filter((entry) => entry.event === 'client_closed');
+      expect(closedEntries).toHaveLength(1);
+      expect(closedEntries[0]!.connectionId).toBeUndefined();
+    });
+
+    it('logs ice_disconnected when the ICE connection enters the disconnected state', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const mocks = setupEventListenerMocks();
+      await mocks.client.dial({ ...baseDialConfig, noReconnect: true });
+
+      const iceHandler = mocks.pcAddEventListener.mock.calls.find(
+        ([event]) => event === 'iceconnectionstatechange'
+      )?.[1] as (() => void) | undefined;
+      expect(iceHandler).toBeDefined();
+
+      // Act — simulate the ICE state moving to 'disconnected'
+      (
+        mocks.peerConnection as unknown as Record<string, unknown>
+      ).iceConnectionState = 'disconnected';
+      iceHandler!();
+
+      // Assert
+      const disconnectedEntries = writer.mock.calls
+        .map(([entry]) => entry)
+        .filter((entry) => entry.event === 'ice_disconnected');
+      expect(disconnectedEntries).toHaveLength(1);
+      expect(disconnectedEntries[0]!.connectionId).toBeDefined();
     });
   });
 });

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -39,7 +39,12 @@ import { NavigationService } from '../gen/service/navigation/v1/navigation_conne
 import { SLAMService } from '../gen/service/slam/v1/slam_connect';
 import { VisionService } from '../gen/service/vision/v1/vision_connect';
 import { writeDebugLog } from '../debug';
-import { dialDirect, dialWebRTC, wrapTransportWithDebugLogging, type DialOptions } from '../rpc';
+import {
+  dialDirect,
+  dialWebRTC,
+  wrapTransportWithDebugLogging,
+  type DialOptions,
+} from '../rpc';
 import { clientHeaders } from '../utils';
 import GRPCConnectionManager from './grpc-connection-manager';
 import type { Robot } from './robot';
@@ -1191,7 +1196,9 @@ export class RobotClient extends EventDispatcher implements Robot {
            */
           const iceState = this.peerConn?.iceConnectionState;
           if (iceState === 'disconnected') {
-            writeDebugLog('ice_disconnected', { connectionId: this.connectionId });
+            writeDebugLog('ice_disconnected', {
+              connectionId: this.connectionId,
+            });
           }
           if (iceState === 'closed') {
             this.onDisconnect();

--- a/src/robot/client.ts
+++ b/src/robot/client.ts
@@ -8,6 +8,7 @@ import {
   type Transport,
 } from '@connectrpc/connect';
 import { backOff, type IBackOffOptions } from 'exponential-backoff';
+import { UuidTool } from 'uuid-tool';
 import { isCredential, type Credentials } from '../app/viam-transport';
 import { DIAL_TIMEOUT } from '../constants';
 import { EventDispatcher, MachineConnectionEvent } from '../events';
@@ -37,7 +38,8 @@ import { MotionService } from '../gen/service/motion/v1/motion_connect';
 import { NavigationService } from '../gen/service/navigation/v1/navigation_connect';
 import { SLAMService } from '../gen/service/slam/v1/slam_connect';
 import { VisionService } from '../gen/service/vision/v1/vision_connect';
-import { dialDirect, dialWebRTC, type DialOptions } from '../rpc';
+import { writeDebugLog } from '../debug';
+import { dialDirect, dialWebRTC, wrapTransportWithDebugLogging, type DialOptions } from '../rpc';
 import { clientHeaders } from '../utils';
 import GRPCConnectionManager from './grpc-connection-manager';
 import type { Robot } from './robot';
@@ -397,6 +399,8 @@ export class RobotClient extends EventDispatcher implements Robot {
 
   private currentRetryAttempt = 0;
   private isReconnecting = false;
+
+  private connectionId: string | undefined;
 
   private onICEConnectionStateChange?: () => void;
   private onDataChannelClose?: (event: Event) => void;
@@ -1012,6 +1016,7 @@ export class RobotClient extends EventDispatcher implements Robot {
   }
 
   public async disconnect() {
+    writeDebugLog('client_closed', { connectionId: this.connectionId });
     this.emit(MachineConnectionEvent.DISCONNECTING, {});
 
     if (this.currentDialAbortSignal && this.dialing) {
@@ -1073,6 +1078,8 @@ export class RobotClient extends EventDispatcher implements Robot {
       return;
     }
 
+    const connectionId = UuidTool.newUuid();
+
     this.connecting = new Promise<void>((resolve) => {
       this.connectResolve = resolve;
     });
@@ -1096,6 +1103,13 @@ export class RobotClient extends EventDispatcher implements Robot {
     }
 
     try {
+      writeDebugLog('dial_started', {
+        connectionId,
+        method: this.webrtcOptions.enabled ? 'webrtc' : 'grpc',
+        host: this.serviceHost,
+        attempt: this.currentRetryAttempt,
+      });
+
       // inject source into header, like `viam-app` if provided
       const mergedHeaders = new Headers(clientHeaders);
       if (extraHeaders) {
@@ -1162,6 +1176,7 @@ export class RobotClient extends EventDispatcher implements Robot {
 
         this.peerConn = webRTCConn.peerConnection;
         this.dataChannel = webRTCConn.dataChannel;
+        this.connectionId = connectionId;
 
         this.cleanupEventListeners();
 
@@ -1174,7 +1189,11 @@ export class RobotClient extends EventDispatcher implements Robot {
            * connection getting closed, so restarting ice is not a valid way to
            * recover.
            */
-          if (this.peerConn?.iceConnectionState === 'closed') {
+          const iceState = this.peerConn?.iceConnectionState;
+          if (iceState === 'disconnected') {
+            writeDebugLog('ice_disconnected', { connectionId: this.connectionId });
+          }
+          if (iceState === 'closed') {
             this.onDisconnect();
           }
         };
@@ -1190,7 +1209,10 @@ export class RobotClient extends EventDispatcher implements Robot {
         this.onDataChannelClose = (event: Event) => this.onDisconnect(event);
         this.dataChannel.addEventListener('close', this.onDataChannelClose);
 
-        this.transport = webRTCConn.transport;
+        this.transport = wrapTransportWithDebugLogging(
+          webRTCConn.transport,
+          connectionId
+        );
 
         this.onTrack = (event: RTCTrackEvent) => {
           const [eventStream] = event.streams;
@@ -1213,7 +1235,11 @@ export class RobotClient extends EventDispatcher implements Robot {
 
         this.peerConn.addEventListener('track', this.onTrack);
       } else {
-        this.transport = await dialDirect(this.serviceHost, opts);
+        this.connectionId = connectionId;
+        this.transport = wrapTransportWithDebugLogging(
+          await dialDirect(this.serviceHost, opts),
+          connectionId
+        );
         await this.gRPCConnectionManager.start();
       }
 
@@ -1223,11 +1249,22 @@ export class RobotClient extends EventDispatcher implements Robot {
 
       this.robotServiceClient = createClient(RobotService, clientTransport);
 
+      writeDebugLog('dial_success', {
+        connectionId,
+        method: this.webrtcOptions.enabled ? 'webrtc' : 'grpc',
+        host: this.serviceHost,
+      });
       this.emit(MachineConnectionEvent.CONNECTED, {});
     } catch (error) {
       // Need to catch the error to properly emit disconnect but
       // also throw the error so reconnect backoff keeps retrying.
       // TODO(ethanlook): clean this up
+      writeDebugLog('dial_failed', {
+        connectionId,
+        method: this.webrtcOptions.enabled ? 'webrtc' : 'grpc',
+        host: this.serviceHost,
+        error: error instanceof Error ? error.message : String(error),
+      });
       if (!this.isReconnecting) {
         this.emit(MachineConnectionEvent.DISCONNECTED, {});
       }

--- a/src/rpc/__tests__/dial.spec.ts
+++ b/src/rpc/__tests__/dial.spec.ts
@@ -494,9 +494,7 @@ describe('wrapTransportWithDebugLogging', () => {
   const mockMethod = { name: 'TestMethod' } as MethodInfo;
   const connectionId = 'test-connection-id';
 
-  const makeStreamResponse = (
-    messages: AnyMessage[]
-  ): StreamResponse => {
+  const makeStreamResponse = (messages: AnyMessage[]): StreamResponse => {
     const gen = function* gen() {
       for (const msg of messages) {
         yield msg;
@@ -543,13 +541,18 @@ describe('wrapTransportWithDebugLogging', () => {
       const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
-      vi.mocked(transport.unary).mockResolvedValue(
-        {} as UnaryResponse
-      );
+      vi.mocked(transport.unary).mockResolvedValue({} as UnaryResponse);
 
       // Act
       const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
-      await wrapped.unary(mockService, mockMethod, undefined, undefined, undefined, {});
+      await wrapped.unary(
+        mockService,
+        mockMethod,
+        undefined,
+        undefined,
+        undefined,
+        {}
+      );
 
       // Assert
       const events = writer.mock.calls.map(([entry]) => entry.event);
@@ -575,7 +578,14 @@ describe('wrapTransportWithDebugLogging', () => {
       // Act & Assert
       const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
       await expect(
-        wrapped.unary(mockService, mockMethod, undefined, undefined, undefined, {})
+        wrapped.unary(
+          mockService,
+          mockMethod,
+          undefined,
+          undefined,
+          undefined,
+          {}
+        )
       ).rejects.toThrow('rpc failed');
 
       const [responseEntry] = writer.mock.calls[1]!;
@@ -612,7 +622,9 @@ describe('wrapTransportWithDebugLogging', () => {
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       const messages = [{}, {}, {}] as AnyMessage[];
-      vi.mocked(transport.stream).mockResolvedValue(makeStreamResponse(messages));
+      vi.mocked(transport.stream).mockResolvedValue(
+        makeStreamResponse(messages)
+      );
 
       // Act
       const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
@@ -651,7 +663,9 @@ describe('wrapTransportWithDebugLogging', () => {
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       const messages = [{ a: 1 }, { a: 2 }] as unknown as AnyMessage[];
-      vi.mocked(transport.stream).mockResolvedValue(makeStreamResponse(messages));
+      vi.mocked(transport.stream).mockResolvedValue(
+        makeStreamResponse(messages)
+      );
 
       // Act
       const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
@@ -677,7 +691,9 @@ describe('wrapTransportWithDebugLogging', () => {
       const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
-      vi.mocked(transport.stream).mockRejectedValue(new Error('stream open failed'));
+      vi.mocked(transport.stream).mockRejectedValue(
+        new Error('stream open failed')
+      );
 
       // Act & Assert
       const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
@@ -706,11 +722,12 @@ describe('wrapTransportWithDebugLogging', () => {
       const transport = createMockTransport();
       const streamError = new Error('mid-stream error');
 
-      const failingMessages = function* failingMessages(): Generator<AnyMessage> {
-        yield {} as AnyMessage;
-        yield {} as AnyMessage;
-        throw streamError;
-      };
+      const failingMessages =
+        function* failingMessages(): Generator<AnyMessage> {
+          yield {} as AnyMessage;
+          yield {} as AnyMessage;
+          throw streamError;
+        };
 
       vi.mocked(transport.stream).mockResolvedValue({
         stream: true,

--- a/src/rpc/__tests__/dial.spec.ts
+++ b/src/rpc/__tests__/dial.spec.ts
@@ -14,7 +14,7 @@ import {
   AuthenticatedTransport,
   wrapTransportWithDebugLogging,
 } from '../dial';
-import { setDebugLogWriter } from '../../debug';
+import { setDebugLogWriter, type DebugLogEntry } from '../../debug';
 
 import {
   TEST_URL,
@@ -491,21 +491,23 @@ describe('dialDirect', () => {
 
 describe('wrapTransportWithDebugLogging', () => {
   const mockService = { typeName: 'test.TestService' } as ServiceType;
-  const mockMethod = { name: 'TestMethod' } as MethodInfo<AnyMessage, AnyMessage>;
+  const mockMethod = { name: 'TestMethod' } as MethodInfo;
   const connectionId = 'test-connection-id';
 
   const makeStreamResponse = (
     messages: AnyMessage[]
-  ): StreamResponse<AnyMessage, AnyMessage> => {
-    async function* gen() {
+  ): StreamResponse => {
+    const gen = function* gen() {
       for (const msg of messages) {
         yield msg;
       }
-    }
-    return { stream: true, message: gen() } as unknown as StreamResponse<
-      AnyMessage,
-      AnyMessage
-    >;
+    };
+    return { stream: true, message: gen() } as unknown as StreamResponse;
+  };
+
+  // Returns a new empty async generator instance for use as stream input.
+  const makeEmptyInput = async function* makeEmptyInput() {
+    // no input messages
   };
 
   afterEach(() => {
@@ -517,7 +519,7 @@ describe('wrapTransportWithDebugLogging', () => {
     it('delegates to the underlying transport with no writer set', async () => {
       // Arrange
       const transport = createMockTransport();
-      const mockResponse = {} as UnaryResponse<AnyMessage, AnyMessage>;
+      const mockResponse = {} as UnaryResponse;
       vi.mocked(transport.unary).mockResolvedValue(mockResponse);
 
       // Act
@@ -538,11 +540,11 @@ describe('wrapTransportWithDebugLogging', () => {
 
     it('logs grpc_request then grpc_response on success', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       vi.mocked(transport.unary).mockResolvedValue(
-        {} as UnaryResponse<AnyMessage, AnyMessage>
+        {} as UnaryResponse
       );
 
       // Act
@@ -565,7 +567,7 @@ describe('wrapTransportWithDebugLogging', () => {
 
     it('logs grpc_response with error field and rethrows on failure', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       vi.mocked(transport.unary).mockRejectedValue(new Error('rpc failed'));
@@ -597,7 +599,7 @@ describe('wrapTransportWithDebugLogging', () => {
         undefined,
         undefined,
         undefined,
-        (async function* () {})()
+        makeEmptyInput()
       );
 
       // Assert — same object reference proves the short-circuit path was taken
@@ -606,7 +608,7 @@ describe('wrapTransportWithDebugLogging', () => {
 
     it('logs grpc_request once and grpc_response per message', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       const messages = [{}, {}, {}] as AnyMessage[];
@@ -620,7 +622,7 @@ describe('wrapTransportWithDebugLogging', () => {
         undefined,
         undefined,
         undefined,
-        (async function* () {})()
+        makeEmptyInput()
       );
       for await (const _ of resp.message) {
         /* consume */
@@ -645,7 +647,7 @@ describe('wrapTransportWithDebugLogging', () => {
 
     it('yields all original messages unchanged', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       const messages = [{ a: 1 }, { a: 2 }] as unknown as AnyMessage[];
@@ -659,7 +661,7 @@ describe('wrapTransportWithDebugLogging', () => {
         undefined,
         undefined,
         undefined,
-        (async function* () {})()
+        makeEmptyInput()
       );
       const received: AnyMessage[] = [];
       for await (const msg of resp.message) {
@@ -672,7 +674,7 @@ describe('wrapTransportWithDebugLogging', () => {
 
     it('logs grpc_response with error when transport.stream rejects', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       vi.mocked(transport.stream).mockRejectedValue(new Error('stream open failed'));
@@ -686,7 +688,7 @@ describe('wrapTransportWithDebugLogging', () => {
           undefined,
           undefined,
           undefined,
-          (async function* () {})()
+          makeEmptyInput()
         )
       ).rejects.toThrow('stream open failed');
 
@@ -699,21 +701,21 @@ describe('wrapTransportWithDebugLogging', () => {
 
     it('logs grpc_response with error on mid-stream failure', async () => {
       // Arrange
-      const writer = vi.fn();
+      const writer = vi.fn<[DebugLogEntry]>();
       setDebugLogWriter(writer);
       const transport = createMockTransport();
       const streamError = new Error('mid-stream error');
 
-      async function* failingMessages(): AsyncGenerator<AnyMessage> {
+      const failingMessages = function* failingMessages(): Generator<AnyMessage> {
         yield {} as AnyMessage;
         yield {} as AnyMessage;
         throw streamError;
-      }
+      };
 
       vi.mocked(transport.stream).mockResolvedValue({
         stream: true,
         message: failingMessages(),
-      } as unknown as StreamResponse<AnyMessage, AnyMessage>);
+      } as unknown as StreamResponse);
 
       // Act
       const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
@@ -723,7 +725,7 @@ describe('wrapTransportWithDebugLogging', () => {
         undefined,
         undefined,
         undefined,
-        (async function* () {})()
+        makeEmptyInput()
       );
 
       await expect(async () => {

--- a/src/rpc/__tests__/dial.spec.ts
+++ b/src/rpc/__tests__/dial.spec.ts
@@ -4,13 +4,17 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Code, ConnectError } from '@connectrpc/connect';
+import type { StreamResponse, UnaryResponse } from '@connectrpc/connect';
+import type { AnyMessage, MethodInfo, ServiceType } from '@bufbuild/protobuf';
 
 import {
   dialWebRTC,
   dialDirect,
   validateDialOptions,
   AuthenticatedTransport,
+  wrapTransportWithDebugLogging,
 } from '../dial';
+import { setDebugLogWriter } from '../../debug';
 
 import {
   TEST_URL,
@@ -482,5 +486,260 @@ describe('dialDirect', () => {
 
     // Assert
     expect(result).toBeInstanceOf(AuthenticatedTransport);
+  });
+});
+
+describe('wrapTransportWithDebugLogging', () => {
+  const mockService = { typeName: 'test.TestService' } as ServiceType;
+  const mockMethod = { name: 'TestMethod' } as MethodInfo<AnyMessage, AnyMessage>;
+  const connectionId = 'test-connection-id';
+
+  const makeStreamResponse = (
+    messages: AnyMessage[]
+  ): StreamResponse<AnyMessage, AnyMessage> => {
+    async function* gen() {
+      for (const msg of messages) {
+        yield msg;
+      }
+    }
+    return { stream: true, message: gen() } as unknown as StreamResponse<
+      AnyMessage,
+      AnyMessage
+    >;
+  };
+
+  afterEach(() => {
+    setDebugLogWriter(undefined);
+    vi.restoreAllMocks();
+  });
+
+  describe('unary', () => {
+    it('delegates to the underlying transport with no writer set', async () => {
+      // Arrange
+      const transport = createMockTransport();
+      const mockResponse = {} as UnaryResponse<AnyMessage, AnyMessage>;
+      vi.mocked(transport.unary).mockResolvedValue(mockResponse);
+
+      // Act
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      const result = await wrapped.unary(
+        mockService,
+        mockMethod,
+        undefined,
+        undefined,
+        undefined,
+        {}
+      );
+
+      // Assert
+      expect(result).toBe(mockResponse);
+      expect(transport.unary).toHaveBeenCalledOnce();
+    });
+
+    it('logs grpc_request then grpc_response on success', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const transport = createMockTransport();
+      vi.mocked(transport.unary).mockResolvedValue(
+        {} as UnaryResponse<AnyMessage, AnyMessage>
+      );
+
+      // Act
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      await wrapped.unary(mockService, mockMethod, undefined, undefined, undefined, {});
+
+      // Assert
+      const events = writer.mock.calls.map(([entry]) => entry.event);
+      expect(events).toEqual(['grpc_request', 'grpc_response']);
+
+      const [requestEntry] = writer.mock.calls[0]!;
+      expect(requestEntry.connectionId).toBe(connectionId);
+      expect(requestEntry.type).toBe('unary');
+      expect(requestEntry.method).toBe('test.TestService/TestMethod');
+
+      const [responseEntry] = writer.mock.calls[1]!;
+      expect(responseEntry.connectionId).toBe(connectionId);
+      expect(responseEntry.error).toBeUndefined();
+    });
+
+    it('logs grpc_response with error field and rethrows on failure', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const transport = createMockTransport();
+      vi.mocked(transport.unary).mockRejectedValue(new Error('rpc failed'));
+
+      // Act & Assert
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      await expect(
+        wrapped.unary(mockService, mockMethod, undefined, undefined, undefined, {})
+      ).rejects.toThrow('rpc failed');
+
+      const [responseEntry] = writer.mock.calls[1]!;
+      expect(responseEntry.event).toBe('grpc_response');
+      expect(responseEntry.error).toBe('rpc failed');
+    });
+  });
+
+  describe('stream', () => {
+    it('returns the original response object directly when no writer is set', async () => {
+      // Arrange
+      const transport = createMockTransport();
+      const mockResponse = makeStreamResponse([]);
+      vi.mocked(transport.stream).mockResolvedValue(mockResponse);
+
+      // Act
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      const result = await wrapped.stream(
+        mockService,
+        mockMethod,
+        undefined,
+        undefined,
+        undefined,
+        (async function* () {})()
+      );
+
+      // Assert — same object reference proves the short-circuit path was taken
+      expect(result).toBe(mockResponse);
+    });
+
+    it('logs grpc_request once and grpc_response per message', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const transport = createMockTransport();
+      const messages = [{}, {}, {}] as AnyMessage[];
+      vi.mocked(transport.stream).mockResolvedValue(makeStreamResponse(messages));
+
+      // Act
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      const resp = await wrapped.stream(
+        mockService,
+        mockMethod,
+        undefined,
+        undefined,
+        undefined,
+        (async function* () {})()
+      );
+      for await (const _ of resp.message) {
+        /* consume */
+      }
+
+      // Assert
+      const requestCalls = writer.mock.calls.filter(
+        ([entry]) => entry.event === 'grpc_request'
+      );
+      const responseCalls = writer.mock.calls.filter(
+        ([entry]) => entry.event === 'grpc_response'
+      );
+      expect(requestCalls).toHaveLength(1);
+      expect(responseCalls).toHaveLength(3);
+
+      for (const [entry] of responseCalls) {
+        expect(entry.connectionId).toBe(connectionId);
+        expect(entry.type).toBe('stream');
+        expect(entry.error).toBeUndefined();
+      }
+    });
+
+    it('yields all original messages unchanged', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const transport = createMockTransport();
+      const messages = [{ a: 1 }, { a: 2 }] as unknown as AnyMessage[];
+      vi.mocked(transport.stream).mockResolvedValue(makeStreamResponse(messages));
+
+      // Act
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      const resp = await wrapped.stream(
+        mockService,
+        mockMethod,
+        undefined,
+        undefined,
+        undefined,
+        (async function* () {})()
+      );
+      const received: AnyMessage[] = [];
+      for await (const msg of resp.message) {
+        received.push(msg);
+      }
+
+      // Assert
+      expect(received).toEqual(messages);
+    });
+
+    it('logs grpc_response with error when transport.stream rejects', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const transport = createMockTransport();
+      vi.mocked(transport.stream).mockRejectedValue(new Error('stream open failed'));
+
+      // Act & Assert
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      await expect(
+        wrapped.stream(
+          mockService,
+          mockMethod,
+          undefined,
+          undefined,
+          undefined,
+          (async function* () {})()
+        )
+      ).rejects.toThrow('stream open failed');
+
+      const responseCalls = writer.mock.calls.filter(
+        ([entry]) => entry.event === 'grpc_response'
+      );
+      expect(responseCalls).toHaveLength(1);
+      expect(responseCalls[0]![0].error).toBe('stream open failed');
+    });
+
+    it('logs grpc_response with error on mid-stream failure', async () => {
+      // Arrange
+      const writer = vi.fn();
+      setDebugLogWriter(writer);
+      const transport = createMockTransport();
+      const streamError = new Error('mid-stream error');
+
+      async function* failingMessages(): AsyncGenerator<AnyMessage> {
+        yield {} as AnyMessage;
+        yield {} as AnyMessage;
+        throw streamError;
+      }
+
+      vi.mocked(transport.stream).mockResolvedValue({
+        stream: true,
+        message: failingMessages(),
+      } as unknown as StreamResponse<AnyMessage, AnyMessage>);
+
+      // Act
+      const wrapped = wrapTransportWithDebugLogging(transport, connectionId);
+      const resp = await wrapped.stream(
+        mockService,
+        mockMethod,
+        undefined,
+        undefined,
+        undefined,
+        (async function* () {})()
+      );
+
+      await expect(async () => {
+        for await (const _ of resp.message) {
+          /* consume */
+        }
+      }).rejects.toThrow('mid-stream error');
+
+      // Assert — 2 successful messages + 1 error
+      const responseCalls = writer.mock.calls.filter(
+        ([entry]) => entry.event === 'grpc_response'
+      );
+      expect(responseCalls).toHaveLength(3);
+      expect(responseCalls[0]![0].error).toBeUndefined();
+      expect(responseCalls[1]![0].error).toBeUndefined();
+      expect(responseCalls[2]![0].error).toBe('mid-stream error');
+    });
   });
 });

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -303,7 +303,7 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
     }
     // Wrap resp.message in a generator so we can log each individual message.
     // The caller receives a normal StreamResponse and iterates it as usual.
-    async function* wrappedMessages(): AsyncIterable<O> {
+    const wrappedMessages = async function* wrappedMessages(): AsyncIterable<O> {
       try {
         for await (const msg of resp.message) {
           writeDebugLog('grpc_response', { connectionId, type: 'stream', method: rpcMethod });
@@ -318,7 +318,7 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
         });
         throw error;
       }
-    }
+    };
     return { ...resp, message: wrappedMessages() };
   };
 

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -273,11 +273,14 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
     input: AsyncIterable<PartialMessage<I>>,
     contextValues?: ContextValues
   ): Promise<StreamResponse<I, O>> => {
+    // Skip wrapping entirely when logging is disabled — avoids generator overhead per message.
     if (!isDebugLogEnabled()) {
       return transport.stream(service, method, signal, timeoutMs, header, input, contextValues);
     }
     const rpcMethod = `${service.typeName}/${method.name}`;
     writeDebugLog('grpc_request', { connectionId, type: 'stream', method: rpcMethod });
+    // Separate try/catch for stream establishment vs. message iteration so we can
+    // distinguish a failure to open the stream from a mid-stream error.
     let resp: StreamResponse<I, O>;
     try {
       resp = await transport.stream(
@@ -298,6 +301,8 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
       });
       throw error;
     }
+    // Wrap resp.message in a generator so we can log each individual message.
+    // The caller receives a normal StreamResponse and iterates it as usual.
     async function* wrappedMessages(): AsyncIterable<O> {
       try {
         for await (const msg of resp.message) {

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -29,6 +29,7 @@ import { newPeerConnectionForClient } from './peer';
 
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { isCredential, type Credentials } from '../app/viam-transport';
+import { isDebugLogEnabled, writeDebugLog } from '../debug';
 import { SignalingExchange } from './signaling-exchange';
 import { UuidTool } from 'uuid-tool';
 
@@ -217,6 +218,106 @@ const enableGRPCTraceLogging = <T extends Transport>(
   }
 
   return transport;
+};
+
+export const wrapTransportWithDebugLogging = <T extends Transport>(
+  transport: T,
+  connectionId: string
+): T => {
+  const patchedUnary: typeof transport.unary = async <
+    I extends Message<I> = AnyMessage,
+    O extends Message<O> = AnyMessage,
+  >(
+    service: ServiceType,
+    method: MethodInfo<I, O>,
+    signal: AbortSignal | undefined,
+    timeoutMs: number | undefined,
+    header: HeadersInit | undefined,
+    message: PartialMessage<I>,
+    contextValues?: ContextValues
+  ): Promise<UnaryResponse<I, O>> => {
+    const rpcMethod = `${service.typeName}/${method.name}`;
+    writeDebugLog('grpc_request', { connectionId, type: 'unary', method: rpcMethod });
+    try {
+      const resp = await transport.unary(
+        service,
+        method,
+        signal,
+        timeoutMs,
+        header,
+        message,
+        contextValues
+      );
+      writeDebugLog('grpc_response', { connectionId, type: 'unary', method: rpcMethod });
+      return resp;
+    } catch (error) {
+      writeDebugLog('grpc_response', {
+        connectionId,
+        type: 'unary',
+        method: rpcMethod,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  };
+
+  const patchedStream: typeof transport.stream = async <
+    I extends Message<I> = AnyMessage,
+    O extends Message<O> = AnyMessage,
+  >(
+    service: ServiceType,
+    method: MethodInfo<I, O>,
+    signal: AbortSignal | undefined,
+    timeoutMs: number | undefined,
+    header: HeadersInit | undefined,
+    input: AsyncIterable<PartialMessage<I>>,
+    contextValues?: ContextValues
+  ): Promise<StreamResponse<I, O>> => {
+    if (!isDebugLogEnabled()) {
+      return transport.stream(service, method, signal, timeoutMs, header, input, contextValues);
+    }
+    const rpcMethod = `${service.typeName}/${method.name}`;
+    writeDebugLog('grpc_request', { connectionId, type: 'stream', method: rpcMethod });
+    let resp: StreamResponse<I, O>;
+    try {
+      resp = await transport.stream(
+        service,
+        method,
+        signal,
+        timeoutMs,
+        header,
+        input,
+        contextValues
+      );
+    } catch (error) {
+      writeDebugLog('grpc_response', {
+        connectionId,
+        type: 'stream',
+        method: rpcMethod,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+    async function* wrappedMessages(): AsyncIterable<O> {
+      try {
+        for await (const msg of resp.message) {
+          writeDebugLog('grpc_response', { connectionId, type: 'stream', method: rpcMethod });
+          yield msg;
+        }
+      } catch (error) {
+        writeDebugLog('grpc_response', {
+          connectionId,
+          type: 'stream',
+          method: rpcMethod,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    }
+    return { ...resp, message: wrappedMessages() };
+  };
+
+  return { ...transport, unary: patchedUnary, stream: patchedStream };
 };
 
 export const dialDirect = async (

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -237,7 +237,11 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
     contextValues?: ContextValues
   ): Promise<UnaryResponse<I, O>> => {
     const rpcMethod = `${service.typeName}/${method.name}`;
-    writeDebugLog('grpc_request', { connectionId, type: 'unary', method: rpcMethod });
+    writeDebugLog('grpc_request', {
+      connectionId,
+      type: 'unary',
+      method: rpcMethod,
+    });
     try {
       const resp = await transport.unary(
         service,
@@ -248,7 +252,11 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
         message,
         contextValues
       );
-      writeDebugLog('grpc_response', { connectionId, type: 'unary', method: rpcMethod });
+      writeDebugLog('grpc_response', {
+        connectionId,
+        type: 'unary',
+        method: rpcMethod,
+      });
       return resp;
     } catch (error) {
       writeDebugLog('grpc_response', {
@@ -275,10 +283,22 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
   ): Promise<StreamResponse<I, O>> => {
     // Skip wrapping entirely when logging is disabled — avoids generator overhead per message.
     if (!isDebugLogEnabled()) {
-      return transport.stream(service, method, signal, timeoutMs, header, input, contextValues);
+      return transport.stream(
+        service,
+        method,
+        signal,
+        timeoutMs,
+        header,
+        input,
+        contextValues
+      );
     }
     const rpcMethod = `${service.typeName}/${method.name}`;
-    writeDebugLog('grpc_request', { connectionId, type: 'stream', method: rpcMethod });
+    writeDebugLog('grpc_request', {
+      connectionId,
+      type: 'stream',
+      method: rpcMethod,
+    });
     // Separate try/catch for stream establishment vs. message iteration so we can
     // distinguish a failure to open the stream from a mid-stream error.
     let resp: StreamResponse<I, O>;
@@ -303,22 +323,27 @@ export const wrapTransportWithDebugLogging = <T extends Transport>(
     }
     // Wrap resp.message in a generator so we can log each individual message.
     // The caller receives a normal StreamResponse and iterates it as usual.
-    const wrappedMessages = async function* wrappedMessages(): AsyncIterable<O> {
-      try {
-        for await (const msg of resp.message) {
-          writeDebugLog('grpc_response', { connectionId, type: 'stream', method: rpcMethod });
-          yield msg;
+    const wrappedMessages =
+      async function* wrappedMessages(): AsyncIterable<O> {
+        try {
+          for await (const msg of resp.message) {
+            writeDebugLog('grpc_response', {
+              connectionId,
+              type: 'stream',
+              method: rpcMethod,
+            });
+            yield msg;
+          }
+        } catch (error) {
+          writeDebugLog('grpc_response', {
+            connectionId,
+            type: 'stream',
+            method: rpcMethod,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
         }
-      } catch (error) {
-        writeDebugLog('grpc_response', {
-          connectionId,
-          type: 'stream',
-          method: rpcMethod,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      }
-    };
+      };
     return { ...resp, message: wrappedMessages() };
   };
 

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -15,6 +15,7 @@ export {
   cloneHeaders,
   dialDirect,
   dialWebRTC,
+  wrapTransportWithDebugLogging,
   type DialOptions,
   type DialWebRTCOptions,
   type WebRTCConnection,


### PR DESCRIPTION
Adds an opt-in debug logging system via `setDebugLogWriter`. When enabled, the SDK emits structured JSON entries for dial attempts (started/success/failed), gRPC requests and responses (including per-message stream logging), client disconnects, and ICE connectivity loss. Each connection is assigned a UUID so events can be correlated across a session.