### PR TITLE
Change depth mime type to 'image/vnd.viam.dep'

### DIFF
--- a/src/components/camera/camera.ts
+++ b/src/components/camera/camera.ts
@@ -31,7 +31,7 @@ export interface ResponseMetadata {
 export type MimeType =
   | ''
   | 'image/vnd.viam.rgba'
-  | 'image/vnd.viam.depth'
+  | 'image/vnd.viam.dep'
   | 'image/jpeg'
   | 'image/png'
   | 'pointcloud/pcd'


### PR DESCRIPTION
The current Viam depth image mimetype value is wrong, see: https://github.com/viamrobotics/rdk/blob/main/utils/mime.go#L24

I can confirm on live machines that depth image sources return mime types of `image/vnd.viam.dep`