### PR TITLE
chore: bump claude-ci-workflows to v2.2.3

### DIFF
--- a/.github/workflows/claude-ci-fix.yml
+++ b/.github/workflows/claude-ci-fix.yml
@@ -21,8 +21,8 @@ jobs:
         github.event.workflow_run.conclusion == 'failure' &&
         startsWith(github.event.workflow_run.head_branch, 'claude/')
       )
-    # viamrobotics/claude-ci-workflows@v2.1.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+    # viamrobotics/claude-ci-workflows@v2.2.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-ci-fix.yml@1916036d3e24a46782ee028f25673df61bb4cfb2
     with:
       run_id: ${{ github.event.workflow_run.id || inputs.run_id }}
       branch: ${{ github.event.workflow_run.head_branch || inputs.branch }}

--- a/.github/workflows/claude-dependabot-sweep.yml
+++ b/.github/workflows/claude-dependabot-sweep.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   sweep:
     if: github.repository_owner == 'viamrobotics'
-    # viamrobotics/claude-ci-workflows@v2.1.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+    # viamrobotics/claude-ci-workflows@v2.2.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-dependabot-sweep.yml@1916036d3e24a46782ee028f25673df61bb4cfb2
     with:
       install_command: npm ci
       allowed_tools: 'Edit,Read,Write,Glob,Grep,Bash(make *),Bash(npm install*),Bash(npm ci*),Bash(npm update*),Bash(npm outdated*),Bash(npm ls*),Bash(npm view*),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr create*),Bash(gh pr view*),Bash(gh issue comment*),Bash(gh issue view*)'

--- a/.github/workflows/claude-jira.yml
+++ b/.github/workflows/claude-jira.yml
@@ -50,8 +50,8 @@ on:
 
 jobs:
   call-jira:
-    # viamrobotics/claude-ci-workflows@v2.1.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+    # viamrobotics/claude-ci-workflows@v2.2.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-jira.yml@1916036d3e24a46782ee028f25673df61bb4cfb2
     with:
       ticket_id: ${{ github.event.client_payload.ticket_id || inputs.ticket_id }}
       summary: ${{ github.event.client_payload.summary || inputs.summary }}

--- a/.github/workflows/claude-pr-assistant.yml
+++ b/.github/workflows/claude-pr-assistant.yml
@@ -15,8 +15,8 @@ jobs:
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
       )
-    # viamrobotics/claude-ci-workflows@v2.1.0
-    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@97b61edeb3aebf3b9bfc93129ac9beae053e5aab
+    # viamrobotics/claude-ci-workflows@v2.2.3
+    uses: viamrobotics/claude-ci-workflows/.github/workflows/claude-pr-assistant.yml@1916036d3e24a46782ee028f25673df61bb4cfb2
     with:
       install_command: npm ci && make build-buf
       allowed_tools: 'Edit,Read,Write,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(make *),Bash(git config *),Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git status*),Bash(git diff*),Bash(git log*),Bash(git checkout *),Bash(git branch *),Bash(git rev-parse *),Bash(git fetch *),Bash(gh pr diff*),Bash(gh pr view*),Bash(gh api repos/*/pulls/*/comments*)'


### PR DESCRIPTION
## What

Bumps all four Claude reusable-workflow callers from **v2.1.0** (`97b61ed`) to **v2.2.3** (`1916036`, latest):

- `claude-ci-fix.yml`
- `claude-pr-assistant.yml`
- `claude-jira.yml`
- `claude-dependabot-sweep.yml`

## Why

[Claude CI Fix](https://github.com/viamrobotics/viam-typescript-sdk/actions/runs/27781183131) and Claude PR Assistant were failing with `startup_failure` — the reusable workflow never started, no jobs ran.

Diagnosis:
- The YAML is valid and the caller inputs/secrets match the reusable-workflow interface, so it isn't a typo in our files.
- It's **deterministic**, not flaky: on the same commit a run was `skipped` (the `if` didn't match) while another `startup_failure`d (the `if` matched and it tried to invoke the reusable workflow). It had been latent since the v2.1.0 bump (#955) on June 4 — June 18 was simply the first time a real `claude/*` CI failure / `@claude` mention made the condition true.
- v2.2.x carries the relevant startup/reference fixes (v2.2.2 replaced a floating `@main` nested reusable-workflow reference with a local `./` ref). v2.2.3 is the version already running successfully in `viamrobotics/app`.

## Verification

- Confirmed all four callers' inputs/secrets remain compatible with the v2.2.3 reusable-workflow interfaces (all required inputs/secrets passed; no undeclared inputs/secrets).
- `actionlint` passes on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)