### PR TITLE
Fix getKinematics throwing on URDF kinematics files

### DIFF
--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -5,10 +5,14 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   type DoCommandRequest,
   DoCommandResponse,
+  GetKinematicsResponse,
   type GetStatusRequest,
   GetStatusResponse,
+  KinematicsFileFormat,
 } from './gen/common/v1/common_pb';
-import { doCommandFromClient, getStatusFromClient } from './utils';
+import { doCommandFromClient, getKinematicsFromClient, getStatusFromClient } from './utils';
+
+const encode = (value: string) => new TextEncoder().encode(value);
 
 describe('doCommandFromClient', () => {
   it('accepts a Struct command', async () => {
@@ -97,5 +101,66 @@ describe('getStatusFromClient', () => {
     expect(requestLogger).toHaveBeenCalledOnce();
     const [loggedRequest] = requestLogger.mock.calls[0] as [GetStatusRequest];
     expect(loggedRequest.name).toBe('test');
+  });
+});
+
+describe('getKinematicsFromClient', () => {
+  it('parses SVA (JSON) kinematics data', async () => {
+    const sva = {
+      name: 'test',
+      kinematic_param_type: 'SVA',
+      joints: [{ id: 'j0', type: 'revolute', parent: 'world', max: 90, min: -90 }],
+      links: [],
+    };
+    const getKinematicsMethod = vi.fn().mockResolvedValue(
+      new GetKinematicsResponse({
+        format: KinematicsFileFormat.SVA,
+        kinematicsData: encode(JSON.stringify(sva)),
+      }),
+    );
+
+    const result = await getKinematicsFromClient(getKinematicsMethod, 'test');
+
+    expect(result).toMatchObject({
+      kinematic_param_type: 'SVA',
+      joints: [{ id: 'j0', max: 90, min: -90 }],
+    });
+  });
+
+  it('does not JSON.parse URDF (XML) kinematics data', async () => {
+    const urdf = '<?xml version="1.0"?>\n<robot name="test"></robot>';
+    const getKinematicsMethod = vi.fn().mockResolvedValue(
+      new GetKinematicsResponse({
+        format: KinematicsFileFormat.URDF,
+        kinematicsData: encode(urdf),
+      }),
+    );
+
+    const result = await getKinematicsFromClient(getKinematicsMethod, 'test');
+
+    expect(result).toMatchObject({
+      name: 'test',
+      kinematic_param_type: 'URDF',
+      joints: [],
+      links: [],
+      urdf,
+    });
+  });
+
+  it('returns an empty UNSPECIFIED result when there is no kinematics data', async () => {
+    const getKinematicsMethod = vi.fn().mockResolvedValue(
+      new GetKinematicsResponse({
+        format: KinematicsFileFormat.UNSPECIFIED,
+      }),
+    );
+
+    const result = await getKinematicsFromClient(getKinematicsMethod, 'test');
+
+    expect(result).toMatchObject({
+      name: 'test',
+      kinematic_param_type: 'UNSPECIFIED',
+      joints: [],
+      links: [],
+    });
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,6 +10,7 @@ import {
   type GetGeometriesResponse,
   GetKinematicsRequest,
   type GetKinematicsResponse,
+  KinematicsFileFormat,
   GetStatusRequest,
   type GetStatusResponse,
   type Mesh,
@@ -116,6 +117,7 @@ export interface KinematicsData {
     min: number;
   }[];
   links: Frame[];
+  urdf?: string;
 }
 
 /** Newer kinematics return shape that includes meshes */
@@ -147,8 +149,27 @@ export const getKinematicsFromClient = async function getKinematicsFromClient(
   const response = await getKinematicsMethod(request, callOptions);
 
   const decoder = new TextDecoder('utf-8');
-  const jsonString = decoder.decode(response.kinematicsData);
-  const parsedKinematicsData = JSON.parse(jsonString) as KinematicsData;
+  const rawData = decoder.decode(response.kinematicsData);
+
+  let parsedKinematicsData: KinematicsData;
+  if (response.format === KinematicsFileFormat.URDF) {
+    parsedKinematicsData = {
+      name,
+      kinematic_param_type: 'URDF',
+      joints: [],
+      links: [],
+      urdf: rawData,
+    };
+  } else if (rawData.length > 0) {
+    parsedKinematicsData = JSON.parse(rawData) as KinematicsData;
+  } else {
+    parsedKinematicsData = {
+      name,
+      kinematic_param_type: 'UNSPECIFIED',
+      joints: [],
+      links: [],
+    };
+  }
 
   return {
     ...parsedKinematicsData,


### PR DESCRIPTION
`getKinematicsFromClient` unconditionally `JSON.parse`d the `kinematics_data` bytes returned by `GetKinematics`, ignoring the response `format`. For an arm configured with a URDF/XML kinematics file, `kinematics_data` is XML (`<?xml ...`), so `JSON.parse` threw `SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data`. That rejection propagated to every caller of `getKinematics` (e.g. joint-limit sliders in downstream UIs), surfacing as an error and blocking the control.

`GetKinematicsResponse` carries a `format` enum (`SVA`, `URDF`, `UNSPECIFIED`) precisely to distinguish JSON payloads from XML payloads. The fix branches on it.

### Changes

- `getKinematicsFromClient` (`src/utils.ts`) now branches on `response.format`:
  - **SVA** (and legacy non-empty payloads): parse as JSON, unchanged behavior.
  - **URDF**: do not `JSON.parse`. `kinematics_data` is JSON for SVA models but XML for URDF models; branching on `format` means we never `JSON.parse` URDF/XML. Returns `{ name, kinematic_param_type: 'URDF', joints: [], links: [], urdf: <raw xml> }`.
  - **UNSPECIFIED / empty**: return an empty `UNSPECIFIED` result instead of throwing on `JSON.parse('')`.
- `KinematicsData` (`src/utils.ts`) gains an optional `urdf?: string` field. It holds the raw URDF (XML) file contents, present only when `kinematic_param_type` is `'URDF'`, since URDF payloads are XML and cannot be represented as parsed SVA joints/links. This keeps the URDF file available to consumers (e.g. 3D viewers) that previously could not receive it at all because the call threw.

### Testing

`npm test` (`src/utils.spec.ts`) — 10 passed, including three new `getKinematicsFromClient` cases:
- parses SVA (JSON) kinematics data,
- does not `JSON.parse` URDF (XML) kinematics data (the regression; previously threw `SyntaxError: JSON.parse: unexpected character`),
- returns an empty `UNSPECIFIED` result when there is no kinematics data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014WohBAkN9G7VBrNfyJFGeV
