### PR TITLE
APP-14871: Report WebRTC connection metadata after dialing

### DIFF
--- a/src/__tests__/mocks/webrtc.ts
+++ b/src/__tests__/mocks/webrtc.ts
@@ -5,12 +5,14 @@ export const createMockPeerConnection = (
   addEventListenerFn = vi.fn(),
   removeEventListenerFn = vi.fn(),
   iceConnectionState: RTCIceConnectionState = 'connected',
+  getStatsFn = vi.fn().mockResolvedValue(new Map()),
 ): RTCPeerConnection => {
   return {
     close: closeFn,
     addEventListener: addEventListenerFn,
     removeEventListener: removeEventListenerFn,
     iceConnectionState,
+    getStats: getStatsFn,
   } as unknown as RTCPeerConnection;
 };
 

--- a/src/rpc/__tests__/dial-report.spec.ts
+++ b/src/rpc/__tests__/dial-report.spec.ts
@@ -1,0 +1,275 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import { Code, ConnectError, type Client } from '@connectrpc/connect';
+
+import type { SignalingService } from '../../gen/proto/rpc/webrtc/v1/signaling_connect';
+import {
+  ConnectionSignalingPath,
+  DialStage,
+  ICECandidateType,
+  type ReportConnectionMetadataRequest,
+  SDKType,
+} from '../../gen/proto/rpc/webrtc/v1/signaling_pb';
+import {
+  classifyCandidate,
+  classifyConnection,
+  classifySignalingPath,
+  DialStageTracker,
+  failureCodeOf,
+  reportDialOutcome,
+} from '../dial-report';
+import { createMockPeerConnection } from '../../__tests__/mocks/webrtc';
+
+const statsReport = (entries: Record<string, unknown>): RTCStatsReport =>
+  new Map(Object.entries(entries));
+
+const mockSignalingClient = (reportFn = vi.fn().mockResolvedValue({})) =>
+  ({ reportConnectionMetadata: reportFn }) as unknown as Client<typeof SignalingService>;
+
+describe('DialStageTracker', () => {
+  it('only advances forward', () => {
+    const tracker = new DialStageTracker();
+    expect(tracker.reached).toBe(DialStage.UNSPECIFIED);
+    tracker.advance(DialStage.CONFIG_FETCHED);
+    expect(tracker.reached).toBe(DialStage.CONFIG_FETCHED);
+    tracker.advance(DialStage.SIGNALING_CONNECTED);
+    expect(tracker.reached).toBe(DialStage.CONFIG_FETCHED);
+    tracker.advance(DialStage.READY);
+    expect(tracker.reached).toBe(DialStage.READY);
+  });
+});
+
+describe('classifySignalingPath', () => {
+  it.each([
+    ['app.viam.com:443', ConnectionSignalingPath.CLOUD_SIGNALED],
+    ['app.viam.dev', ConnectionSignalingPath.CLOUD_SIGNALED],
+    ['https://app.viam.com:443', ConnectionSignalingPath.CLOUD_SIGNALED],
+    ['APP.VIAM.COM:443', ConnectionSignalingPath.CLOUD_SIGNALED],
+    ['localhost:8080', ConnectionSignalingPath.LOCAL],
+    ['http://127.0.0.1:9000', ConnectionSignalingPath.LOCAL],
+    ['10.1.2.3:443', ConnectionSignalingPath.LOCAL],
+    ['my-robot.abc123.viam.cloud:443', ConnectionSignalingPath.LOCAL],
+  ])('classifies %s', (address, expected) => {
+    expect(classifySignalingPath(address)).toBe(expected);
+  });
+});
+
+describe('failureCodeOf', () => {
+  it('extracts the code from a ConnectError', () => {
+    expect(failureCodeOf(new ConnectError('robot offline', Code.NotFound))).toBe(Code.NotFound);
+  });
+
+  it('maps non-gRPC failures to Unknown', () => {
+    expect(failureCodeOf(new Error('timed out'))).toBe(Code.Unknown);
+  });
+});
+
+describe('classifyCandidate', () => {
+  it.each([
+    ['host', ICECandidateType.ICE_CANDIDATE_TYPE_HOST, ''],
+    ['srflx', ICECandidateType.ICE_CANDIDATE_TYPE_STUN, ''],
+    ['prflx', ICECandidateType.ICE_CANDIDATE_TYPE_STUN, ''],
+    ['relay', ICECandidateType.ICE_CANDIDATE_TYPE_RELAY, '34.0.0.1'],
+  ])('classifies %s candidates', (candidateType, expectedType, expectedAddress) => {
+    const stats = statsReport({
+      c1: { candidateType, address: '34.0.0.1' },
+    });
+    const got = classifyCandidate(stats, 'c1');
+    expect(got.type).toBe(expectedType);
+    expect(got.relayAddress).toBe(expectedAddress);
+  });
+
+  it('falls back to ip when a relay candidate has no address', () => {
+    const stats = statsReport({
+      c1: { candidateType: 'relay', ip: '34.0.0.2' },
+    });
+    expect(classifyCandidate(stats, 'c1').relayAddress).toBe('34.0.0.2');
+  });
+
+  it('classifies a missing candidate as unspecified', () => {
+    const stats = statsReport({
+      c1: { candidateType: 'host' },
+    });
+    expect(classifyCandidate(stats, 'nope').type).toBe(
+      ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED,
+    );
+    expect(classifyCandidate(stats, undefined).type).toBe(
+      ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED,
+    );
+  });
+});
+
+describe('classifyConnection', () => {
+  it("uses the transport's selected candidate pair", async () => {
+    const stats = statsReport({
+      transport: { type: 'transport', selectedCandidatePairId: 'pair-selected' },
+      'pair-selected': {
+        type: 'candidate-pair',
+        localCandidateId: 'local-relay',
+        remoteCandidateId: 'remote-host',
+      },
+      'local-relay': { candidateType: 'relay', address: '34.0.0.1' },
+      'remote-host': { candidateType: 'host', address: '192.168.1.2' },
+    });
+    const pc = createMockPeerConnection(
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      'connected',
+      vi.fn().mockResolvedValue(stats),
+    );
+
+    const { local, remote } = await classifyConnection(pc);
+    expect(local.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_RELAY);
+    expect(local.relayAddress).toBe('34.0.0.1');
+    expect(remote.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_HOST);
+    expect(remote.relayAddress).toBe('');
+  });
+
+  it('falls back to a nominated succeeded pair without transport stats', async () => {
+    const stats = statsReport({
+      'pair-failed': { type: 'candidate-pair', state: 'failed', nominated: false },
+      'pair-selected': {
+        type: 'candidate-pair',
+        state: 'succeeded',
+        nominated: true,
+        localCandidateId: 'local-host',
+        remoteCandidateId: 'remote-host',
+      },
+      'local-host': { candidateType: 'host' },
+      'remote-host': { candidateType: 'host' },
+    });
+    const pc = createMockPeerConnection(
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      'connected',
+      vi.fn().mockResolvedValue(stats),
+    );
+
+    const { local, remote } = await classifyConnection(pc);
+    expect(local.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_HOST);
+    expect(remote.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_HOST);
+  });
+
+  it('classifies both sides as unspecified without a selected pair', async () => {
+    const pc = createMockPeerConnection();
+    const { local, remote } = await classifyConnection(pc);
+    expect(local.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED);
+    expect(remote.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED);
+  });
+});
+
+describe('reportDialOutcome', () => {
+  it('reports a successful dial with the selected candidate pair', async () => {
+    const reportFn = vi.fn().mockResolvedValue({});
+    const stats = statsReport({
+      transport: { type: 'transport', selectedCandidatePairId: 'pair' },
+      pair: { type: 'candidate-pair', localCandidateId: 'l', remoteCandidateId: 'r' },
+      l: { candidateType: 'host' },
+      r: { candidateType: 'host' },
+    });
+    const pc = createMockPeerConnection(
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      'connected',
+      vi.fn().mockResolvedValue(stats),
+    );
+    const stage = new DialStageTracker();
+    stage.advance(DialStage.READY);
+
+    reportDialOutcome(
+      mockSignalingClient(reportFn),
+      { headers: { 'rpc-host': 'my-host' } },
+      pc,
+      stage,
+      Date.now() - 25,
+      ConnectionSignalingPath.CLOUD_SIGNALED,
+    );
+
+    await vi.waitFor(() => {
+      expect(reportFn).toHaveBeenCalledOnce();
+    });
+    const [request, opts] = reportFn.mock.calls[0] as [
+      ReportConnectionMetadataRequest,
+      { timeoutMs: number },
+    ];
+    expect(request.reachedStage).toBe(DialStage.READY);
+    expect(request.sdkType).toBe(SDKType.SDK_TYPE_TYPESCRIPT);
+    expect(request.sdkVersion).toBe(__VERSION__);
+    expect(request.signalingPath).toBe(ConnectionSignalingPath.CLOUD_SIGNALED);
+    expect(request.failureCode).toBe(0);
+    expect(request.durationMs).toBeGreaterThanOrEqual(25);
+    expect(request.local?.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_HOST);
+    expect(request.remote?.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_HOST);
+    expect(opts.timeoutMs).toBe(5000);
+  });
+
+  it('reports a failed dial with the furthest stage and failure code', async () => {
+    const reportFn = vi.fn().mockResolvedValue({});
+    const stage = new DialStageTracker();
+    stage.advance(DialStage.OFFER_SENT);
+
+    reportDialOutcome(
+      mockSignalingClient(reportFn),
+      {},
+      undefined,
+      stage,
+      Date.now(),
+      ConnectionSignalingPath.LOCAL,
+      new ConnectError('robot offline', Code.NotFound),
+    );
+
+    await vi.waitFor(() => {
+      expect(reportFn).toHaveBeenCalledOnce();
+    });
+    const [request] = reportFn.mock.calls[0] as [ReportConnectionMetadataRequest];
+    expect(request.reachedStage).toBe(DialStage.OFFER_SENT);
+    expect(request.failureCode).toBe(Code.NotFound);
+    expect(request.signalingPath).toBe(ConnectionSignalingPath.LOCAL);
+    expect(request.local?.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED);
+    expect(request.remote?.type).toBe(ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED);
+  });
+
+  it('never reports an unimplemented failure (no WebRTC signaler)', async () => {
+    const reportFn = vi.fn().mockResolvedValue({});
+
+    reportDialOutcome(
+      mockSignalingClient(reportFn),
+      {},
+      undefined,
+      new DialStageTracker(),
+      Date.now(),
+      ConnectionSignalingPath.LOCAL,
+      new ConnectError('not implemented', Code.Unimplemented),
+    );
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+    expect(reportFn).not.toHaveBeenCalled();
+  });
+
+  it('swallows report failures', async () => {
+    const reportFn = vi.fn().mockRejectedValue(new Error('send failed'));
+    const stage = new DialStageTracker();
+    stage.advance(DialStage.READY);
+
+    expect(() => {
+      reportDialOutcome(
+        mockSignalingClient(reportFn),
+        {},
+        undefined,
+        stage,
+        Date.now(),
+        ConnectionSignalingPath.LOCAL,
+      );
+    }).not.toThrow();
+
+    await vi.waitFor(() => {
+      expect(reportFn).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/rpc/__tests__/dial.spec.ts
+++ b/src/rpc/__tests__/dial.spec.ts
@@ -13,6 +13,8 @@ import {
   wrapTransportWithDebugLogging,
 } from '../dial';
 import { setDebugLogWriter, type DebugLogEntry } from '../../debug';
+import { DialStage } from '../../gen/proto/rpc/webrtc/v1/signaling_pb';
+import { DialStageTracker } from '../dial-report';
 
 import {
   TEST_URL,
@@ -64,8 +66,11 @@ const setupDialWebRTCMocks = () => {
     },
   });
 
+  const reportConnectionMetadataFn = vi.fn().mockResolvedValue({});
+
   const mockClient = {
     optionalWebRTCConfig: optionalWebRTCConfigFn,
+    reportConnectionMetadata: reportConnectionMetadataFn,
   } as unknown as ReturnType<typeof createClient>;
 
   vi.mocked(createClient).mockReturnValue(mockClient);
@@ -87,6 +92,7 @@ const setupDialWebRTCMocks = () => {
     dataChannel,
     transport,
     signalingExchange,
+    reportConnectionMetadataFn,
   };
 };
 
@@ -238,6 +244,64 @@ describe('dialWebRTC', () => {
     });
   });
 
+  describe('connection metadata reporting', () => {
+    it('reports the dial outcome exactly once on success', async () => {
+      // Arrange
+      const { reportConnectionMetadataFn } = setupDialWebRTCMocks();
+
+      // Act
+      await dialWebRTC(TEST_URL, TEST_HOST);
+
+      // Assert
+      await vi.waitFor(() => {
+        expect(reportConnectionMetadataFn).toHaveBeenCalledOnce();
+      });
+      const [request] = reportConnectionMetadataFn.mock.calls[0] as [
+        { reachedStage: number; failureCode: number },
+      ];
+      expect(request.reachedStage).toBe(DialStage.READY);
+      expect(request.failureCode).toBe(0);
+    });
+
+    it('reports a failed dial exactly once with its failure code', async () => {
+      // Arrange
+      const { signalingExchange, reportConnectionMetadataFn } = setupDialWebRTCMocks();
+      vi.mocked(signalingExchange.doExchange).mockRejectedValueOnce(
+        new ConnectError('robot offline', Code.NotFound),
+      );
+
+      // Act
+      await expect(dialWebRTC(TEST_URL, TEST_HOST)).rejects.toThrow('robot offline');
+
+      // Assert
+      await vi.waitFor(() => {
+        expect(reportConnectionMetadataFn).toHaveBeenCalledOnce();
+      });
+      const [request] = reportConnectionMetadataFn.mock.calls[0] as [
+        { reachedStage: number; failureCode: number },
+      ];
+      expect(request.failureCode).toBe(Code.NotFound);
+      expect(request.reachedStage).toBe(DialStage.CONFIG_FETCHED);
+    });
+
+    it('never reports an unimplemented failure (no WebRTC signaler)', async () => {
+      // Arrange
+      const { signalingExchange, reportConnectionMetadataFn } = setupDialWebRTCMocks();
+      vi.mocked(signalingExchange.doExchange).mockRejectedValueOnce(
+        new ConnectError('not implemented', Code.Unimplemented),
+      );
+
+      // Act
+      await expect(dialWebRTC(TEST_URL, TEST_HOST)).rejects.toThrow('not implemented');
+
+      // Assert
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      expect(reportConnectionMetadataFn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('configuration', () => {
     it('should pass webrtc options to peer connection', async () => {
       // Arrange
@@ -274,6 +338,7 @@ describe('dialWebRTC', () => {
         peerConnection,
         dataChannel,
         { additionalSdpFields, disableTrickleICE: true, rtcConfig },
+        expect.any(DialStageTracker),
       );
     });
   });

--- a/src/rpc/dial-report.ts
+++ b/src/rpc/dial-report.ts
@@ -1,0 +1,212 @@
+/**
+ * Best-effort reporting of WebRTC dial outcomes to the signaling server, mirroring the Go SDK's
+ * connection-metadata telemetry (goutils rpc/wrtc_client_report.go). After a WebRTC dial finishes —
+ * success or failure — the dialing client reports how far the dial got, how it was signaled, how
+ * long it took, and (on success) which ICE candidate pair was selected.
+ */
+
+import { Code, ConnectError, type CallOptions, type Client } from '@connectrpc/connect';
+import type { SignalingService } from '../gen/proto/rpc/webrtc/v1/signaling_connect';
+import {
+  ConnectionSignalingPath,
+  DialStage,
+  ICECandidateType,
+  ReportConnectionMetadataRequest,
+  SDKType,
+} from '../gen/proto/rpc/webrtc/v1/signaling_pb';
+
+/** How long a best-effort report send may take before being abandoned. */
+const REPORT_TIMEOUT_MS = 5000;
+
+/**
+ * Tracks the furthest checkpoint a WebRTC dial reached, so a failed dial can report where it
+ * stopped. Advance only ever moves it forward.
+ */
+export class DialStageTracker {
+  private stage = DialStage.UNSPECIFIED;
+
+  public advance(stage: DialStage): void {
+    if (stage > this.stage) {
+      this.stage = stage;
+    }
+  }
+
+  public get reached(): DialStage {
+    return this.stage;
+  }
+}
+
+/** The Viam app signaling server hosts. */
+const VIAM_CLOUD_SIGNALING_HOSTS = ['app.viam.com', 'app.viam.dev'];
+
+/**
+ * Derives how a connection was signaled from the signaling server address: a Viam app signaling
+ * host is CLOUD_SIGNALED; everything else (localhost, private/LAN addresses, a machine's own
+ * signaling server, etc.) is LOCAL. This SDK has no mDNS discovery, so MDNS_LOCAL is never
+ * reported.
+ */
+export const classifySignalingPath = (signalingAddress: string): ConnectionSignalingPath => {
+  let host = signalingAddress;
+  const schemeIndex = host.indexOf('://');
+  if (schemeIndex >= 0) {
+    host = host.slice(schemeIndex + 3);
+  }
+  [host = ''] = host.split('/');
+  host = host.replace(/:\d+$/u, '').toLowerCase();
+  return VIAM_CLOUD_SIGNALING_HOSTS.includes(host)
+    ? ConnectionSignalingPath.CLOUD_SIGNALED
+    : ConnectionSignalingPath.LOCAL;
+};
+
+export interface CandidateClassification {
+  type: ICECandidateType;
+  relayAddress: string;
+}
+
+const UNSPECIFIED_CANDIDATE: CandidateClassification = {
+  type: ICECandidateType.ICE_CANDIDATE_TYPE_UNSPECIFIED,
+  relayAddress: '',
+};
+
+/**
+ * Maps a single ICE candidate stat to a candidate classification; a missing or unrecognized
+ * candidate yields type UNSPECIFIED. Relay candidates carry the relay server address so the
+ * signaling server can classify the relay provider.
+ */
+export const classifyCandidate = (
+  stats: RTCStatsReport,
+  candidateId: string | undefined,
+): CandidateClassification => {
+  if (candidateId === undefined || candidateId === '') {
+    return UNSPECIFIED_CANDIDATE;
+  }
+  const candidate = stats.get(candidateId) as
+    | { candidateType?: string; address?: string | null; ip?: string | null }
+    | undefined;
+  switch (candidate?.candidateType) {
+    case 'host': {
+      return { type: ICECandidateType.ICE_CANDIDATE_TYPE_HOST, relayAddress: '' };
+    }
+    case 'srflx':
+    case 'prflx': {
+      return { type: ICECandidateType.ICE_CANDIDATE_TYPE_STUN, relayAddress: '' };
+    }
+    case 'relay': {
+      return {
+        type: ICECandidateType.ICE_CANDIDATE_TYPE_RELAY,
+        relayAddress: candidate.address ?? candidate.ip ?? '',
+      };
+    }
+    default: {
+      return UNSPECIFIED_CANDIDATE;
+    }
+  }
+};
+
+/**
+ * Inspects the selected ICE candidate pair and classifies each side: local is this SDK's candidate,
+ * remote is the peer's. It prefers the transport's authoritative selectedCandidatePairId, falling
+ * back to a nominated+succeeded scan where transport stats are unavailable. Both sides are
+ * UNSPECIFIED when no selected pair exists (a failed dial).
+ */
+export const classifyConnection = async (
+  pc: RTCPeerConnection,
+): Promise<{
+  local: CandidateClassification;
+  remote: CandidateClassification;
+}> => {
+  const stats = await pc.getStats();
+
+  let selectedPairId = '';
+  stats.forEach((stat: RTCStats) => {
+    if (stat.type === 'transport') {
+      const transport = stat as RTCTransportStats;
+      if (
+        transport.selectedCandidatePairId !== undefined &&
+        transport.selectedCandidatePairId !== ''
+      ) {
+        selectedPairId = transport.selectedCandidatePairId;
+      }
+    }
+  });
+
+  let pair =
+    selectedPairId === ''
+      ? undefined
+      : (stats.get(selectedPairId) as RTCIceCandidatePairStats | undefined);
+  if (!pair) {
+    stats.forEach((stat: RTCStats) => {
+      if (stat.type === 'candidate-pair') {
+        const candidatePair = stat as RTCIceCandidatePairStats;
+        if (candidatePair.nominated === true && candidatePair.state === 'succeeded') {
+          pair ??= candidatePair;
+        }
+      }
+    });
+  }
+
+  return {
+    local: classifyCandidate(stats, pair?.localCandidateId),
+    remote: classifyCandidate(stats, pair?.remoteCandidateId),
+  };
+};
+
+/**
+ * Extracts the gRPC status code of a failed dial; non-gRPC failures map to Unknown, matching the Go
+ * SDK's status.Code behavior.
+ */
+export const failureCodeOf = (failure: unknown): Code => ConnectError.from(failure).code;
+
+/**
+ * Reports the outcome of one WebRTC dial to the signaling server it dialed through, best-effort and
+ * fire-and-forget: errors are logged, never surfaced, and the dial's caller is never delayed. An
+ * Unimplemented failure means the remote has no WebRTC signaler — a fallback control flow, not a
+ * WebRTC failure — so it is never reported. There is exactly one report per dial: this SDK dials a
+ * single signaling path (no mDNS/cloud racing like the Go SDK), so per-attempt collection is
+ * unnecessary.
+ */
+export const reportDialOutcome = (
+  signalingClient: Client<typeof SignalingService>,
+  callOpts: CallOptions,
+  pc: RTCPeerConnection | undefined,
+  stage: DialStageTracker,
+  dialStartMs: number,
+  signalingPath: ConnectionSignalingPath,
+  failure?: unknown,
+): void => {
+  let failureCode = 0;
+  if (failure !== undefined) {
+    const code = failureCodeOf(failure);
+    if (code === Code.Unimplemented) {
+      return;
+    }
+    failureCode = code;
+  }
+  const durationMs = Math.max(Math.round(Date.now() - dialStartMs), 0);
+
+  const classified = pc
+    ? classifyConnection(pc)
+    : Promise.resolve({
+        local: UNSPECIFIED_CANDIDATE,
+        remote: UNSPECIFIED_CANDIDATE,
+      });
+  classified
+    .then(async ({ local, remote }) =>
+      signalingClient.reportConnectionMetadata(
+        new ReportConnectionMetadataRequest({
+          local,
+          remote,
+          sdkType: SDKType.SDK_TYPE_TYPESCRIPT,
+          reachedStage: stage.reached,
+          durationMs,
+          signalingPath,
+          failureCode,
+          sdkVersion: __VERSION__,
+        }),
+        { ...callOpts, timeoutMs: REPORT_TIMEOUT_MS },
+      ),
+    )
+    .catch((error: unknown) => {
+      console.debug('failed to report connection metadata', error); // eslint-disable-line no-console
+    });
+};

--- a/src/rpc/dial.ts
+++ b/src/rpc/dial.ts
@@ -13,7 +13,8 @@ import { Code, ConnectError, createClient } from '@connectrpc/connect';
 import { AuthService, ExternalAuthService } from '../gen/proto/rpc/v1/auth_connect';
 import { AuthenticateRequest, Credentials as PBCredentials } from '../gen/proto/rpc/v1/auth_pb';
 import { SignalingService } from '../gen/proto/rpc/webrtc/v1/signaling_connect';
-import { WebRTCConfig } from '../gen/proto/rpc/webrtc/v1/signaling_pb';
+import { DialStage, WebRTCConfig } from '../gen/proto/rpc/webrtc/v1/signaling_pb';
+import { classifySignalingPath, DialStageTracker, reportDialOutcome } from './dial-report';
 import { newPeerConnectionForClient } from './peer';
 
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
@@ -549,6 +550,7 @@ export const dialWebRTC = async (
   dialOpts?: DialOptions,
   transportCredentialsInclude = false,
 ): Promise<WebRTCConnection> => {
+  const dialStart = Date.now();
   let usableSignalingAddress = signalingAddress.replace(/\/$/u, '');
   if (dialOpts?.webrtcOptions?.signalingInsecure) {
     // TLS for the signaling connection is determined by the URL scheme passed
@@ -581,29 +583,67 @@ export const dialWebRTC = async (
     transportCredentialsInclude,
   );
 
-  const webrtcOpts = await processWebRTCOpts(signalingClient, callOpts, dialOpts);
+  /**
+   * From here on the dial outcome — success or failure — is reported best-effort to the signaling
+   * server (see dial-report.ts), tracking the furthest stage the dial reached. Failures before the
+   * signaling client exists cannot be reported: there is nothing to report over.
+   */
+  const stage = new DialStageTracker();
+  stage.advance(DialStage.SIGNALING_CONNECTED);
+  const signalingPath = classifySignalingPath(usableSignalingAddress);
 
-  const { pc, dc } = await newPeerConnectionForClient(
-    webrtcOpts.disableTrickleICE,
-    webrtcOpts.rtcConfig,
-    webrtcOpts.additionalSdpFields,
-  );
+  let pc: RTCPeerConnection | undefined;
+  let dc: RTCDataChannel | undefined;
   let successful = false;
-
-  const exchange = new SignalingExchange(signalingClient, callOpts, pc, dc, webrtcOpts);
-
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const dialTimeoutMs = dialOpts?.dialTimeoutMs ?? dialOpts?.dialTimeout;
-  if (dialTimeoutMs !== undefined && dialTimeoutMs > 0) {
-    timeoutId = setTimeout(() => {
-      if (!successful) {
-        exchange.terminate(new Error('timed out'));
-      }
-    }, dialTimeoutMs);
-  }
 
   try {
+    const webrtcOpts = await processWebRTCOpts(signalingClient, callOpts, dialOpts);
+    stage.advance(DialStage.CONFIG_FETCHED);
+
+    const { pc: newPc, dc: newDc } = await newPeerConnectionForClient(
+      webrtcOpts.disableTrickleICE,
+      webrtcOpts.rtcConfig,
+      webrtcOpts.additionalSdpFields,
+    );
+    pc = newPc;
+    dc = newDc;
+
+    newPc.addEventListener('iceconnectionstatechange', () => {
+      if (newPc.iceConnectionState === 'connected' || newPc.iceConnectionState === 'completed') {
+        stage.advance(DialStage.ICE_CONNECTED);
+      }
+    });
+    /**
+     * Advance to DTLS_CONNECTED when the peer connection reaches connected (ICE + DTLS complete),
+     * so a failure between ICE connectivity and data-channel-open can be attributed to DTLS vs the
+     * data channel.
+     */
+    newPc.addEventListener('connectionstatechange', () => {
+      if (newPc.connectionState === 'connected') {
+        stage.advance(DialStage.DTLS_CONNECTED);
+      }
+    });
+
+    const exchange = new SignalingExchange(
+      signalingClient,
+      callOpts,
+      newPc,
+      newDc,
+      webrtcOpts,
+      stage,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const dialTimeoutMs = dialOpts?.dialTimeoutMs ?? dialOpts?.dialTimeout;
+    if (dialTimeoutMs !== undefined && dialTimeoutMs > 0) {
+      timeoutId = setTimeout(() => {
+        if (!successful) {
+          exchange.terminate(new Error('timed out'));
+        }
+      }, dialTimeoutMs);
+    }
+
     const cc = await exchange.doExchange();
 
     if (dialOpts?.externalAuthAddress !== undefined && dialOpts.externalAuthAddress !== '') {
@@ -613,6 +653,8 @@ export const dialWebRTC = async (
     }
 
     successful = true;
+    stage.advance(DialStage.READY);
+    reportDialOutcome(signalingClient, callOpts, newPc, stage, dialStart, signalingPath);
 
     // Wrap the transport with AuthenticatedTransport to inject extraHeaders
     const headers = new Headers(dialOpts?.extraHeaders ?? {});
@@ -620,11 +662,12 @@ export const dialWebRTC = async (
 
     return {
       transport: enableGRPCTraceLogging(wrappedTransport, host),
-      peerConnection: pc,
-      dataChannel: dc,
+      peerConnection: newPc,
+      dataChannel: newDc,
     };
   } catch (error) {
     console.error('error dialing', error); // eslint-disable-line no-console
+    reportDialOutcome(signalingClient, callOpts, pc, stage, dialStart, signalingPath, error);
     throw error;
   } finally {
     if (timeoutId !== undefined) {
@@ -632,8 +675,8 @@ export const dialWebRTC = async (
     }
 
     if (!successful) {
-      pc.close();
-      dc.close();
+      pc?.close();
+      dc?.close();
     }
   }
 };

--- a/src/rpc/signaling-exchange.ts
+++ b/src/rpc/signaling-exchange.ts
@@ -8,10 +8,12 @@ import {
   type CallResponseInitStage,
   type CallResponseUpdateStage,
   CallUpdateRequest,
+  DialStage,
   ICECandidate,
 } from '../gen/proto/rpc/webrtc/v1/signaling_pb';
 import { ClientChannel } from './client-channel';
 import { ConnectionClosedError } from './connection-closed-error';
+import type { DialStageTracker } from './dial-report';
 import type { DialWebRTCOptions } from './dial';
 import { addSdpFields } from './peer';
 import { atob, btoa } from './polyfills';
@@ -44,6 +46,7 @@ export class SignalingExchange {
     private readonly pc: RTCPeerConnection,
     private readonly dc: RTCDataChannel,
     private readonly dialOpts?: DialWebRTCOptions,
+    private readonly dialStage?: DialStageTracker,
   ) {
     this.clientChannel = new ClientChannel(this.pc, this.dc);
   }
@@ -75,6 +78,7 @@ export class SignalingExchange {
 
     // Initiate now the call now that all of our handlers are setup.
     const callResponses = this.signalingClient.call(callRequest, this.callOpts);
+    this.dialStage?.advance(DialStage.OFFER_SENT);
 
     // Start processing the responses asynchronously.
     const responsesProcessed = this.processCallResponses(callResponses);
@@ -189,6 +193,7 @@ export class SignalingExchange {
       return false;
     }
     await this.pc.setRemoteDescription(remoteSDP);
+    this.dialStage?.advance(DialStage.ANSWER_RECEIVED);
     this.awaitingRemoteDescription?.success(true);
 
     if (this.dialOpts?.disableTrickleICE) {


### PR DESCRIPTION
### Description

[APP-14871](https://viam.atlassian.net/browse/APP-14871) Track coturn usage / WebRTC client connection telemetry — the TypeScript SDK port of the Go SDK's dial telemetry in [goutils #583](https://github.com/viamrobotics/goutils/pull/583). App-side receiver in [app #11316](https://github.com/viamrobotics/app/pull/11316).

**Depends on goutils #583**: the `SignalingService.ReportConnectionMetadata` proto additions. `src/gen` is not committed here — CI regenerates from `buf.build/viamrobotics/goutils`, so **builds fail until goutils #583 merges and publishes to the BSR**. Local verification was done with stubs generated from that PR's branch.

**Client (`dialWebRTC`)** — after a WebRTC dial succeeds or fails, reports best-effort to the signaling server it dialed through:
- `reached_stage`: the furthest dial checkpoint, advanced as the dial progresses (`SIGNALING_CONNECTED → CONFIG_FETCHED → OFFER_SENT → ANSWER_RECEIVED → ICE_CONNECTED → DTLS_CONNECTED → READY`). `READY` means success; any earlier value is where a failed dial stopped. `OFFER_SENT`/`ANSWER_RECEIVED` are advanced inside `SignalingExchange` (new optional constructor arg); `ICE_CONNECTED`/`DTLS_CONNECTED` from `iceconnectionstatechange`/`connectionstatechange` listeners.
- `local` / `remote`: the selected ICE candidate pair classified per side as host / stun / relay from `pc.getStats()`, preferring the transport's authoritative `selectedCandidatePairId` with a nominated+succeeded fallback. Relay candidates carry the relay address so app can attribute the provider (Viam coturn vs Twilio).
- `failure_code`: `ConnectError.from(error).code` of a failed dial (non-gRPC failures map to `Unknown`), set only on failure.
- `signaling_path`: classified from the signaling address (`app.viam.com` / `app.viam.dev` → `cloud_signaled`, anything else → `local`). This SDK has no mDNS discovery, so `mdns_local` is never reported.
- `duration_ms` (dial start → ready/failure) and `sdk_type=typescript` / `sdk_version` (`__VERSION__`, the package version).
- The reporting code lives in its own `src/rpc/dial-report.ts`. The send is fire-and-forget with a 5s timeout over the same signaling client the dial used, so it never delays or fails the caller.

**Reporting semantics vs Go** — exactly one report per dial, success or failure:
- This SDK dials a single signaling path (no mDNS/cloud racing), so Go's per-attempt collector/dedup is unnecessary.
- Failures before the signaling client exists cannot be reported (nothing to report over), matching Go, where reporting starts once the signaling server is dialed. `dialWebRTC` was restructured so config-fetch/peer-creation failures after that point are reported too.
- An `Unimplemented` failure (remote has no WebRTC signaler) is fallback control flow, not a WebRTC failure, and is never reported — mirroring Go's `ErrNoWebRTCSignaler` handling.

**Tests**
- `src/rpc/__tests__/dial-report.spec.ts`: stage-tracker forward-only advancement, signaling-path classification, candidate/pair classification (host/stun/relay, relay address, `address`→`ip` fallback, missing pair/candidate), failure-code mapping, and report contents for success / failure / unimplemented-skip / swallowed send errors.
- `dial.spec.ts`: end-to-end through `dialWebRTC` — exactly one report on success (`READY`) and on failure (furthest stage + code), and none on `Unimplemented`.
- Full suite: 426/426 pass; typecheck and lint clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-14871]: https://viam.atlassian.net/browse/APP-14871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ