### PR TITLE
Parse URDF kinematics files into structured joints/links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@connectrpc/connect": "^1.7.0",
         "@connectrpc/connect-web": "^1.7.0",
         "bsonfy": "^1.0.2",
-        "exponential-backoff": "^3.1.3"
+        "exponential-backoff": "^3.1.3",
+        "fast-xml-parser": "^5.8.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.70.0",
@@ -541,6 +542,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
@@ -667,9 +680,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -687,9 +697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -707,9 +714,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -727,9 +731,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,9 +748,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -767,9 +765,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1497,6 +1492,18 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2460,6 +2467,45 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.1.tgz",
+      "integrity": "sha512-tPb5TTWfgfVx5BNSi2xV0eLr89POeXXn0dXIsCJ9m1narrWxeIyx6je9d7Rce/3NyXLbvuQmLkxq+RuxMWejvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2784,6 +2830,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -2993,9 +3051,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3017,9 +3072,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3041,9 +3093,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3065,9 +3114,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3908,6 +3954,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4334,6 +4395,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/supports-color": {
@@ -4921,6 +4997,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@connectrpc/connect-web": "^1.7.0",
         "bsonfy": "^1.0.2",
         "exponential-backoff": "^3.1.3",
-        "fast-xml-parser": "^5.8.0"
+        "fast-xml-parser": "^5.9.3"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.70.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@connectrpc/connect-web": "^1.7.0",
         "bsonfy": "^1.0.2",
         "exponential-backoff": "^3.1.3",
-        "fast-xml-parser": "^5.9.3"
+        "fast-xml-parser": "^5.10.0"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.70.0",
@@ -2484,9 +2484,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
-      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
+      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
       "funding": [
         {
           "type": "github",
@@ -2497,13 +2497,28 @@
       "dependencies": {
         "@nodable/entities": "^2.2.0",
         "fast-xml-builder": "^1.2.0",
-        "is-unsafe": "^1.0.1",
-        "path-expression-matcher": "^1.5.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
         "strnum": "^2.4.1",
-        "xml-naming": "^0.1.0"
+        "xml-naming": "^0.3.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fast-xml-parser/node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2831,9 +2846,9 @@
       }
     },
     "node_modules/is-unsafe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
-      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@connectrpc/connect-web": "^1.7.0",
     "bsonfy": "^1.0.2",
     "exponential-backoff": "^3.1.3",
-    "fast-xml-parser": "^5.9.3"
+    "fast-xml-parser": "^5.10.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.70.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@connectrpc/connect-web": "^1.7.0",
     "bsonfy": "^1.0.2",
     "exponential-backoff": "^3.1.3",
-    "fast-xml-parser": "^5.8.0"
+    "fast-xml-parser": "^5.9.3"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.70.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "@connectrpc/connect": "^1.7.0",
     "@connectrpc/connect-web": "^1.7.0",
     "bsonfy": "^1.0.2",
-    "exponential-backoff": "^3.1.3"
+    "exponential-backoff": "^3.1.3",
+    "fast-xml-parser": "^5.8.0"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.70.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -440,8 +440,6 @@ export {
   type KinematicsData,
 } from './utils';
 
-export { parseUrdf } from './urdf';
-
 export {
   createConsoleLogWriter,
   setDebugLogWriter,

--- a/src/main.ts
+++ b/src/main.ts
@@ -435,7 +435,12 @@ export {
   doCommandFromClient,
   enableDebugLogging,
   getStatusFromClient,
+  type GetKinematicsResult,
+  type GetKinematicsResultWithMeshes,
+  type KinematicsData,
 } from './utils';
+
+export { parseUrdf } from './urdf';
 
 export {
   createConsoleLogWriter,

--- a/src/urdf.spec.ts
+++ b/src/urdf.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { parseUrdf } from './urdf';
+
+const URDF = `<?xml version="1.0" ?>
+<robot name="UF_ROBOT">
+  <link name="world"/>
+
+  <joint name="world_joint" type="fixed">
+    <parent link="world"/>
+    <child link="link_base"/>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+  </joint>
+
+  <link name="link_base">
+    <collision>
+      <geometry>
+        <mesh filename="package://meshes/link_base.stl"/>
+      </geometry>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+    </collision>
+  </link>
+
+  <joint name="joint1" type="revolute">
+    <parent link="link_base"/>
+    <child link="link1"/>
+    <origin rpy="0 0 1.5708" xyz="0 0 0.267"/>
+    <axis xyz="0 0 1"/>
+    <limit effort="50.0" lower="-6.28" upper="6.28" velocity="3.14"/>
+  </joint>
+
+  <link name="link1">
+    <collision>
+      <geometry>
+        <box size="0.1 0.2 0.3"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>`;
+
+describe('parseUrdf', () => {
+  const result = parseUrdf(URDF);
+  const [worldLink, linkBase, link1] = result.links;
+
+  it('reads the robot name and reports SVA params after conversion', () => {
+    expect(result.name).toBe('UF_ROBOT');
+    expect(result.kinematic_param_type).toBe('SVA');
+  });
+
+  it('excludes fixed joints and converts revolute limits to degrees', () => {
+    expect(result.joints).toHaveLength(1);
+    const [joint1] = result.joints;
+    expect(joint1?.id).toBe('joint1');
+    expect(joint1?.type).toBe('revolute');
+    expect(joint1?.parent).toBe('link_base');
+    expect(joint1?.axis).toStrictEqual({ x: 0, y: 0, z: 1 });
+    // ±6.28 rad -> degrees.
+    expect(joint1?.max).toBeCloseTo(359.817, 3);
+    expect(joint1?.min).toBeCloseTo(-359.817, 3);
+  });
+
+  it('derives each link pose from the joint that positions it', () => {
+    expect(result.links).toHaveLength(3);
+
+    // The root link has no positioning joint, so it is parented to the world.
+    expect(worldLink?.parent).toBe('world');
+
+    // link_base is positioned by the fixed world_joint.
+    expect(linkBase?.parent).toBe('world');
+    expect(linkBase?.translation).toEqual({ x: 0, y: 0, z: 0 });
+
+    // link1 is positioned by joint1's origin; 0.267 m -> 267 mm.
+    expect(link1?.parent).toBe('link_base');
+    expect(link1?.translation).toEqual({ x: 0, y: 0, z: 267 });
+    expect(link1?.orientation?.type).toEqual({
+      case: 'eulerAngles',
+      value: { roll: 0, pitch: 0, yaw: 1.5708 },
+    });
+  });
+
+  it('maps mesh geometry, preserving the filename on the label', () => {
+    expect(linkBase?.geometry?.geometryType.case).toBe('mesh');
+    expect(linkBase?.geometry?.label).toBe('package://meshes/link_base.stl');
+  });
+
+  it('maps primitive geometry, converting dimensions to millimeters', () => {
+    expect(link1?.geometry?.geometryType.case).toBe('box');
+    const box = link1?.geometry?.geometryType.value;
+    // "0.1 0.2 0.3" m -> mm.
+    expect(box && 'dimsMm' in box ? box.dimsMm : undefined).toEqual({
+      x: 100,
+      y: 200,
+      z: 300,
+    });
+  });
+
+  it('throws on a document with no <robot> element', () => {
+    expect(() => parseUrdf('<nope/>')).toThrow('missing <robot> element');
+  });
+});

--- a/src/urdf.ts
+++ b/src/urdf.ts
@@ -1,0 +1,260 @@
+import { XMLParser } from 'fast-xml-parser';
+import { Frame } from './gen/app/v1/robot_pb';
+import { Capsule, Geometry, Mesh, RectangularPrism, Sphere } from './gen/common/v1/common_pb';
+import type { Vector3 } from './types';
+import type { KinematicsData } from './utils';
+
+/*
+ * A URDF (Unified Robot Description Format) parser, emitting the SDK's shared
+ * {@link KinematicsData} type so URDF kinematics can be consumed identically to
+ * the native (JSON) kinematics format.
+ *
+ * URDF is XML describing a robot as a tree of rigid `<link>`s connected by
+ * `<joint>`s. A joint carries the static transform (its `<origin>`) from its
+ * parent link to its child link, so each link's pose in {@link KinematicsData}
+ * is derived from the joint for which it is the child.
+ */
+
+const ATTRIBUTE_PREFIX = '@_';
+
+/** The raw, attribute-bearing object produced by {@link XMLParser}. */
+type XMLNode = Record<string, unknown>;
+
+/** A parsed URDF `<origin>` element. */
+type UrdfOrigin = XMLNode;
+
+/** Read an XML attribute (e.g. `name="foo"`) off a parsed node. */
+const getAttribute = (node: unknown, attribute: string): string | undefined => {
+  if (node === null || typeof node !== 'object') {
+    return undefined;
+  }
+  const value = (node as XMLNode)[`${ATTRIBUTE_PREFIX}${attribute}`];
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  return value === undefined ? undefined : String(value);
+};
+
+/** Parse a string to a number, falling back to `defaultValue` when invalid. */
+const parseNumber = (value: string | undefined, defaultValue = 0): number => {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const num = Number.parseFloat(value);
+  return Number.isNaN(num) ? defaultValue : num;
+};
+
+/** Parse a space-separated `"x y z"` string into a {@link Vector3}. */
+const parseVector3 = (value: string | undefined, defaultValue?: Vector3): Vector3 => {
+  const fallback = defaultValue ?? { x: 0, y: 0, z: 0 };
+  if (value === undefined) {
+    return fallback;
+  }
+  const parts = value.trim().split(/\s+/u);
+  if (parts.length !== 3) {
+    return fallback;
+  }
+  return {
+    x: parseNumber(parts[0], fallback.x),
+    y: parseNumber(parts[1], fallback.y),
+    z: parseNumber(parts[2], fallback.z),
+  };
+};
+
+/*
+ * URDF expresses lengths in meters and angles in radians, but the RDK spatial
+ * model (SVA) it is converted into expects millimeters and degrees. These
+ * mirror `utils.MetersToMM` and `utils.RadToDeg` in RDK's URDF parser.
+ */
+
+/** Convert meters to millimeters. */
+const metersToMm = (meters: number): number => meters * 1000;
+
+/** Convert each component of a meter-valued vector to millimeters. */
+const vector3MetersToMm = (vector: Vector3): Vector3 => ({
+  x: metersToMm(vector.x),
+  y: metersToMm(vector.y),
+  z: metersToMm(vector.z),
+});
+
+/** Convert radians to degrees. */
+const radToDeg = (radians: number): number => (radians * 180) / Math.PI;
+
+/** XML elements that repeat are arrays; singletons are not. Normalize to array. */
+const ensureArray = <T>(element: T | T[] | undefined): T[] => {
+  if (element === undefined) {
+    return [];
+  }
+  return Array.isArray(element) ? element : [element];
+};
+
+/** Convert a URDF `<origin rpy="...">` into a Frame orientation. */
+const orientationFromRpy = (
+  origin: UrdfOrigin | undefined,
+): { type: { case: string; value: { roll: number; pitch: number; yaw: number } } } | undefined => {
+  const rpy = getAttribute(origin, 'rpy');
+  if (rpy === undefined) {
+    return undefined;
+  }
+  const { x: roll, y: pitch, z: yaw } = parseVector3(rpy);
+  return {
+    type: { case: 'eulerAngles' as const, value: { roll, pitch, yaw } },
+  };
+};
+
+/** Convert a URDF `<geometry>` element into a common Geometry message. */
+const processGeometry = (link: XMLNode, label: string): Geometry | undefined => {
+  const source = ensureArray(link.collision ?? link.visual)[0] as XMLNode | undefined;
+  const geometry = source?.geometry as XMLNode | undefined;
+  if (geometry === undefined) {
+    return undefined;
+  }
+
+  if (geometry.mesh !== undefined) {
+    // The mesh bytes themselves arrive separately (keyed by filepath); the
+    // filename is preserved on the label so callers can resolve them.
+    return new Geometry({
+      label: getAttribute(geometry.mesh, 'filename') ?? label,
+      geometryType: { case: 'mesh', value: new Mesh() },
+    });
+  }
+  if (geometry.box !== undefined) {
+    return new Geometry({
+      label,
+      geometryType: {
+        case: 'box',
+        value: new RectangularPrism({
+          dimsMm: vector3MetersToMm(parseVector3(getAttribute(geometry.box, 'size'))),
+        }),
+      },
+    });
+  }
+  if (geometry.sphere !== undefined) {
+    return new Geometry({
+      label,
+      geometryType: {
+        case: 'sphere',
+        value: new Sphere({
+          radiusMm: metersToMm(parseNumber(getAttribute(geometry.sphere, 'radius'))),
+        }),
+      },
+    });
+  }
+  if (geometry.cylinder !== undefined) {
+    // Viam has no cylinder primitive; a capsule is the closest approximation.
+    return new Geometry({
+      label,
+      geometryType: {
+        case: 'capsule',
+        value: new Capsule({
+          radiusMm: metersToMm(parseNumber(getAttribute(geometry.cylinder, 'radius'))),
+          lengthMm: metersToMm(parseNumber(getAttribute(geometry.cylinder, 'length'))),
+        }),
+      },
+    });
+  }
+  return undefined;
+};
+
+/**
+ * Convert a URDF `<joint>` element into a KinematicsData joint, applying RDK's limit conventions:
+ * revolute limits are degrees, prismatic limits are millimeters, and a continuous joint is an
+ * unbounded revolute joint.
+ */
+const processJoint = (joint: XMLNode): KinematicsData['joints'][number] => {
+  const type = getAttribute(joint, 'type') ?? '';
+  const lower = parseNumber(getAttribute(joint.limit, 'lower'));
+  const upper = parseNumber(getAttribute(joint.limit, 'upper'));
+
+  let min = lower;
+  let max = upper;
+  let resolvedType = type;
+  switch (type) {
+    case 'continuous': {
+      // A continuous joint is a revolute joint with no limits.
+      resolvedType = 'revolute';
+      min = Number.NEGATIVE_INFINITY;
+      max = Number.POSITIVE_INFINITY;
+      break;
+    }
+    case 'prismatic': {
+      min = metersToMm(lower);
+      max = metersToMm(upper);
+      break;
+    }
+    case 'revolute': {
+      min = radToDeg(lower);
+      max = radToDeg(upper);
+      break;
+    }
+    default: {
+      break;
+    }
+  }
+
+  return {
+    id: getAttribute(joint, 'name') ?? '',
+    type: resolvedType,
+    parent: getAttribute(joint.parent, 'link') ?? '',
+    axis: parseVector3(getAttribute(joint.axis, 'xyz'), { x: 1, y: 0, z: 0 }),
+    max,
+    min,
+  };
+};
+
+/**
+ * Convert a URDF `<link>` into a Frame. The link's pose comes from the joint for which it is the
+ * child (its parent link and `<origin>` transform); a link with no such joint (e.g. the root) is
+ * parented to the world frame.
+ */
+const processLink = (link: XMLNode, joint: XMLNode | undefined): Frame => {
+  const origin = joint?.origin as UrdfOrigin | undefined;
+  return new Frame({
+    parent: joint ? (getAttribute(joint.parent, 'link') ?? 'world') : 'world',
+    translation: vector3MetersToMm(parseVector3(getAttribute(origin, 'xyz'))),
+    orientation: orientationFromRpy(origin),
+    geometry: processGeometry(link, getAttribute(link, 'name') ?? ''),
+  });
+};
+
+/**
+ * Parse a URDF XML document into the SDK's shared {@link KinematicsData} shape.
+ *
+ * @param urdf - The URDF document as an XML string.
+ */
+export const parseUrdf = (urdf: string): KinematicsData => {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: ATTRIBUTE_PREFIX,
+    allowBooleanAttributes: true,
+  });
+  const robot = (parser.parse(urdf) as XMLNode).robot as XMLNode | undefined;
+  if (robot === undefined) {
+    throw new Error('Invalid URDF: missing <robot> element');
+  }
+
+  const jointElements = ensureArray(robot.joint) as XMLNode[];
+  const linkElements = ensureArray(robot.link) as XMLNode[];
+
+  // Index each joint by the child link it positions.
+  const jointByChild = new Map<string, XMLNode>();
+  for (const joint of jointElements) {
+    const child = getAttribute(joint.child, 'link');
+    if (child !== undefined) {
+      jointByChild.set(child, joint);
+    }
+  }
+
+  return {
+    name: getAttribute(robot, 'name') ?? '',
+    // The URDF has been converted into RDK's spatial (SVA) parameters:
+    // millimeters, degrees, and joint-relative frame transforms.
+    kinematic_param_type: 'SVA',
+    // Fixed joints are static transforms rather than movable joints; they still
+    // position their child link but are not actuatable, so they are omitted here.
+    joints: jointElements
+      .filter((joint) => getAttribute(joint, 'type') !== 'fixed')
+      .map((joint) => processJoint(joint)),
+    links: linkElements.map((link) =>
+      processLink(link, jointByChild.get(getAttribute(link, 'name') ?? '')),
+    ),
+  };
+};

--- a/src/urdf.ts
+++ b/src/urdf.ts
@@ -89,7 +89,9 @@ const ensureArray = <T>(element: T | T[] | undefined): T[] => {
 /** Convert a URDF `<origin rpy="...">` into a Frame orientation. */
 const orientationFromRpy = (
   origin: UrdfOrigin | undefined,
-): { type: { case: string; value: { roll: number; pitch: number; yaw: number } } } | undefined => {
+):
+  | { type: { case: 'eulerAngles'; value: { roll: number; pitch: number; yaw: number } } }
+  | undefined => {
   const rpy = getAttribute(origin, 'rpy');
   if (rpy === undefined) {
     return undefined;

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -127,8 +127,42 @@ describe('getKinematicsFromClient', () => {
     });
   });
 
-  it('does not JSON.parse URDF (XML) kinematics data', async () => {
-    const urdf = '<?xml version="1.0"?>\n<robot name="test"></robot>';
+  it('parses URDF (XML) kinematics data into SVA joints/links', async () => {
+    const urdf = `<?xml version="1.0"?>
+<robot name="test">
+  <link name="base"/>
+  <link name="link1"/>
+  <joint name="joint1" type="revolute">
+    <parent link="base"/>
+    <child link="link1"/>
+    <origin rpy="0 0 0" xyz="0 0 0.1"/>
+    <axis xyz="0 0 1"/>
+    <limit lower="-3.14" upper="3.14"/>
+  </joint>
+</robot>`;
+    const getKinematicsMethod = vi.fn().mockResolvedValue(
+      new GetKinematicsResponse({
+        format: KinematicsFileFormat.URDF,
+        kinematicsData: encode(urdf),
+      }),
+    );
+
+    const result = await getKinematicsFromClient(getKinematicsMethod, 'test');
+
+    expect(result).toMatchObject({
+      name: 'test',
+      // Parsed URDF is reported as SVA (converted units) so downstream
+      // consumers gated on 'SVA' pick up the joint limits.
+      kinematic_param_type: 'SVA',
+      joints: [{ id: 'joint1', type: 'revolute' }],
+      urdf,
+    });
+    expect((result as { links: unknown[] }).links).toHaveLength(2);
+    expect((result as { joints: unknown[] }).joints).toHaveLength(1);
+  });
+
+  it('falls back to a raw-XML result when URDF cannot be parsed', async () => {
+    const urdf = '<nope/>'; // no <robot> element -> parseUrdf throws
     const getKinematicsMethod = vi.fn().mockResolvedValue(
       new GetKinematicsResponse({
         format: KinematicsFileFormat.URDF,

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -159,6 +159,11 @@ describe('getKinematicsFromClient', () => {
     });
     expect((result as { links: unknown[] }).links).toHaveLength(2);
     expect((result as { joints: unknown[] }).joints).toHaveLength(1);
+
+    const [joint] = (result as { joints: { min: number; max: number }[] }).joints;
+    // -3.14/3.14 rad -> degrees
+    expect(joint?.max).toBeCloseTo(179.909, 3);
+    expect(joint?.min).toBeCloseTo(-179.909, 3);
   });
 
   it('falls back to a raw-XML result when URDF cannot be parsed', async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ import {
   type Mesh,
 } from './gen/common/v1/common_pb';
 import type { Options, Vector3 } from './types';
+import { parseUrdf } from './urdf';
 
 export const clientHeaders = new Headers({
   viam_client: `typescript;v${__VERSION__};${apiVersion}`,
@@ -153,13 +154,20 @@ export const getKinematicsFromClient = async function getKinematicsFromClient(
 
   let parsedKinematicsData: KinematicsData;
   if (response.format === KinematicsFileFormat.URDF) {
-    parsedKinematicsData = {
-      name,
-      kinematic_param_type: 'URDF',
-      joints: [],
-      links: [],
-      urdf: rawData,
-    };
+    try {
+      // parseUrdf yields SVA-unit joints/links and kinematic_param_type: 'SVA';
+      // retain the raw XML so URDF origin is still knowable via `urdf`.
+      parsedKinematicsData = { ...parseUrdf(rawData), urdf: rawData };
+    } catch {
+      // #978 never-throw fallback: unparseable URDF still returns safely.
+      parsedKinematicsData = {
+        name,
+        kinematic_param_type: 'URDF',
+        joints: [],
+        links: [],
+        urdf: rawData,
+      };
+    }
   } else if (rawData.length > 0) {
     parsedKinematicsData = JSON.parse(rawData) as KinematicsData;
   } else {


### PR DESCRIPTION
## Summary

Builds on #978 (which stopped `getKinematics` from throwing on URDF/XML kinematics files) by actually **parsing** the URDF into the SDK's shared `KinematicsData` shape, so downstream UIs (joint-limit sliders, 3D viewers) get real structured data instead of just raw XML.

Brings in the `parseUrdf` converter authored in #977 and wires it into `getKinematicsFromClient`:

- **Valid URDF** -> parsed into SVA-unit `joints`/`links` (meters->mm, radians->degrees, fixed joints filtered, `continuous`->unbounded `revolute`, geometry mapped). Reported as `kinematic_param_type: 'SVA'` so consumers gated on `'SVA'` pick up joint limits, with the raw XML retained on the `urdf` field for origin/mesh resolution.
- **Malformed/empty URDF** -> degrades to #978's never-throw passthrough (`'URDF'`, empty joints/links, raw `urdf`). The never-throw guarantee is preserved.
- **SVA JSON / UNSPECIFIED** -> unchanged from #978.

`parseUrdf` and the kinematics types (`KinematicsData`, `GetKinematicsResult`, `GetKinematicsResultWithMeshes`) are now exported from the public API.

### Relationship to #977
This supersedes the code in #977 by rebasing its `parseUrdf` onto the merged #978 fix. `src/urdf.ts` is taken verbatim from #977 **except** one type fix: `orientationFromRpy` annotated its return `case` as `string`, widening the `'eulerAngles'` literal so it wasn't assignable to `Frame.orientation`. Narrowed to the literal (type-only; runtime unchanged). **This fix should also land in #977.**

### Notes / follow-ups
- Adds `fast-xml-parser` as a runtime dependency (~29 KB gzip). Because `parseUrdf` is a static public export, this lands in the bundle for all consumers; code-splitting it is an API-shape change best handled as a follow-up.
- Conversion paths for continuous/prismatic joints and the `meshesByUrdfFilepath` passthrough are not yet unit-tested (all `parseUrdf` internals from #977) -- candidate follow-up.

## Test Plan

- [x] `npm test` -- 409 passing (29 files), including new `getKinematicsFromClient` cases: valid URDF -> SVA joints/links with converted degree limits + retained `urdf`; malformed URDF -> never-throw fallback.
- [x] `src/urdf.spec.ts` -- parseUrdf conversion suite (name, fixed-joint exclusion, rad->deg, link poses, mesh/box geometry, throws on missing `<robot>`).
- [x] `tsc` -- 0 errors; `npm run build` clean; `eslint` clean.
- [ ] Verify against a real arm configured with a URDF kinematics file that joint-limit sliders populate downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBrD9CPVH6CgGyQwo9cMjW
